### PR TITLE
Use a set instead of a vector for `:exclude-when-defined-by`

### DIFF
--- a/projects/grain-core/resources/clj-kondo.exports/ai.obney.grain/grain-core/config.edn
+++ b/projects/grain-core/resources/clj-kondo.exports/ai.obney.grain/grain-core/config.edn
@@ -5,9 +5,9 @@
                         ai.obney.grain.periodic-task.interface/defperiodic hooks.grain/defperiodic
                         ai.obney.grain.schema-util.interface/defschemas hooks.grain/defschemas}}
  :linters {:clojure-lsp/unused-public-var
-           {:exclude-when-defined-by [ai.obney.grain.command-processor.interface/defcommand
-                                      ai.obney.grain.query-processor.interface/defquery
-                                      ai.obney.grain.read-model-processor.interface/defreadmodel
-                                      ai.obney.grain.todo-processor-v2.interface/defprocessor
-                                      ai.obney.grain.periodic-task.interface/defperiodic
-                                      ai.obney.grain.schema-util.interface/defschemas]}}}
+           {:exclude-when-defined-by #{ai.obney.grain.command-processor.interface/defcommand
+                                       ai.obney.grain.query-processor.interface/defquery
+                                       ai.obney.grain.read-model-processor.interface/defreadmodel
+                                       ai.obney.grain.todo-processor-v2.interface/defprocessor
+                                       ai.obney.grain.periodic-task.interface/defperiodic
+                                       ai.obney.grain.schema-util.interface/defschemas}}}}


### PR DESCRIPTION
Having this as a vector causes [clojure-lsp to fail to start up](https://github.com/clojure-lsp/clojure-lsp/issues/2292).