### PR TITLE
Fix kondo hook dropping handler opts map from analysis

### DIFF
--- a/projects/grain-core-v2/resources/clj-kondo.exports/ai.obney.grain/grain-core-v2/hooks/grain_v2.clj
+++ b/projects/grain-core-v2/resources/clj-kondo.exports/ai.obney.grain/grain-core-v2/hooks/grain_v2.clj
@@ -30,6 +30,7 @@
                  (concat
                    (when ?docstring [?docstring])
                    [args-node]
+                   (when ?opts [?opts])
                    body)))
        :defined-by defined-by})))
 


### PR DESCRIPTION
Fixes #16

## Problem

The `def-handler-macro` clj-kondo hook captures the optional opts map (`?opts`) that handler macros accept between the name and the arg vector, but never emits it into the synthetic `defn`. As a result, any var referenced **only** inside an opts map — e.g. `{:authorized? my-ns/authenticated?}` on a `defcommand` — is invisible to clj-kondo, so clojure-lsp reports it as an unused public var.

## Fix

Emit `?opts` as the first body form of the generated `defn` so its symbols get resolved:

```clojure
 (concat
   (when ?docstring [?docstring])
   [args-node]
+  (when ?opts [?opts])
   body)
```

Affects all five handler macros that share the helper: `defcommand`, `defquery`, `defreadmodel`, `defprocessor`, `defperiodic`.

## Verification

With the fix applied, a predicate referenced only in a `defcommand` opts map (e.g. `{:authorized? auth/authenticated?}`) is now recorded in clj-kondo's `var-usages` analysis, and clojure-lsp no longer flags the var as unused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)