### PR TITLE
Move event id creation into event store and out of event construction

### DIFF
--- a/bases/control-plane-test-base/src/ai/obney/grain/control_plane_test_base/core.clj
+++ b/bases/control-plane-test-base/src/ai/obney/grain/control_plane_test_base/core.clj
@@ -320,7 +320,12 @@
 ;; (for use from REPL) ;;
 ;; ------------------- ;;
 
-(declare all-events)
+(defn all-events
+  "Show all non-tx events for a tenant."
+  [system tenant-id]
+  (into []
+    (remove #(= :grain/tx (:event/type %)))
+    (es/read (:event-store system) {:tenant-id tenant-id})))
 
 (defn create-tenant!
   "Create a tenant by appending an initial event."
@@ -422,13 +427,6 @@
   "Reset the slow-work effect execution counter. Call before each test scenario."
   []
   (reset! slow-work-effect-executions {}))
-
-(defn all-events
-  "Show all non-tx events for a tenant."
-  [system tenant-id]
-  (into []
-    (remove #(= :grain/tx (:event/type %)))
-    (es/read (:event-store system) {:tenant-id tenant-id})))
 
 (defn scheduled-trigger-summary
   "Summary of scheduled triggers and their processing for a tenant."

--- a/bases/control-plane-test-base/src/ai/obney/grain/control_plane_test_base/core.clj
+++ b/bases/control-plane-test-base/src/ai/obney/grain/control_plane_test_base/core.clj
@@ -320,6 +320,8 @@
 ;; (for use from REPL) ;;
 ;; ------------------- ;;
 
+(declare all-events)
+
 (defn create-tenant!
   "Create a tenant by appending an initial event."
   [system tenant-id]
@@ -333,6 +335,34 @@
   (es/append (:event-store system)
     {:tenant-id tenant-id
      :events [(es/->event {:type :test/counter-incremented :body {}})]}))
+
+(defn append-checkpoint-gap!
+  "Construct A before B, commit and process B, then append stale A.
+   Returns the caller and final IDs. This is a deterministic reproduction of
+   the append/checkpoint ordering gap."
+  [system tenant-id timeout-ms]
+  (let [event-a (es/->event {:type :test/counter-incremented :body {:label :a}})
+        event-b (es/->event {:type :test/counter-incremented :body {:label :b}})
+        [persisted-b] (es/append (:event-store system)
+                                {:tenant-id tenant-id :events [event-b]})
+        deadline (+ (System/currentTimeMillis) timeout-ms)
+        checkpointed? (fn []
+                        (some #(and (= :grain/todo-processor-checkpoint (:event/type %))
+                                    (= (:event/id persisted-b) (:triggered-by %)))
+                              (all-events system tenant-id)))]
+    (loop []
+      (cond
+        (checkpointed?) nil
+        (>= (System/currentTimeMillis) deadline)
+        (throw (ex-info "Timed out waiting for B checkpoint"
+                        {:tenant-id tenant-id :event-id (:event/id persisted-b)}))
+        :else (do (Thread/sleep 50) (recur))))
+    (let [[persisted-a] (es/append (:event-store system)
+                                  {:tenant-id tenant-id :events [event-a]})]
+      {:caller-a-id (:event/id event-a)
+       :caller-b-id (:event/id event-b)
+       :final-a-id (:event/id persisted-a)
+       :final-b-id (:event/id persisted-b)})))
 
 (defn submit-slow-work!
   "Append a slow-work event to a tenant."

--- a/bases/control-plane-test-base/src/ai/obney/grain/control_plane_test_base/core.clj
+++ b/bases/control-plane-test-base/src/ai/obney/grain/control_plane_test_base/core.clj
@@ -337,9 +337,10 @@
      :events [(es/->event {:type :test/counter-incremented :body {}})]}))
 
 (defn append-checkpoint-gap!
-  "Construct A before B, commit and process B, then append stale A.
-   Returns the caller and final IDs. This is a deterministic reproduction of
-   the append/checkpoint ordering gap."
+  "Construct A before B without persistence metadata, commit and process B,
+   then append A. Returns the store-assigned IDs and timestamps. Against the
+   former constructor-owned metadata contract this reproduces the checkpoint
+   ordering gap deterministically."
   [system tenant-id timeout-ms]
   (let [event-a (es/->event {:type :test/counter-incremented :body {:label :a}})
         event-b (es/->event {:type :test/counter-incremented :body {:label :b}})
@@ -359,10 +360,10 @@
         :else (do (Thread/sleep 50) (recur))))
     (let [[persisted-a] (es/append (:event-store system)
                                   {:tenant-id tenant-id :events [event-a]})]
-      {:caller-a-id (:event/id event-a)
-       :caller-b-id (:event/id event-b)
-       :final-a-id (:event/id persisted-a)
-       :final-b-id (:event/id persisted-b)})))
+      {:final-a-id (:event/id persisted-a)
+       :final-a-timestamp (:event/timestamp persisted-a)
+       :final-b-id (:event/id persisted-b)
+       :final-b-timestamp (:event/timestamp persisted-b)})))
 
 (defn submit-slow-work!
   "Append a slow-work event to a tenant."

--- a/components/control-plane/test/ai/obney/grain/control_plane/test_kit.clj
+++ b/components/control-plane/test/ai/obney/grain/control_plane/test_kit.clj
@@ -214,11 +214,12 @@
 (defn cp6-lease-fencing [make-env]
   (testing "CP6: two nodes checkpointing the same event — only one succeeds"
     (let [{:keys [store cleanup]} (make-env)
-          tenant-1 (uuid/v4)
-          event (es/->event {:type :test/domain-event :body {:n 1}})]
+          tenant-1 (uuid/v4)]
       (try
-        (es/append store {:tenant-id tenant-1 :events [event]})
-        (let [processor-name :test/fencing-proc
+        (let [[event] (es/append store
+                        {:tenant-id tenant-1
+                         :events [(es/->event {:type :test/domain-event :body {:n 1}})]})
+              processor-name :test/fencing-proc
               handler (fn [_] {})
               result-a (tp/process-event
                          {:event event :handler-fn handler :event-store store
@@ -247,16 +248,19 @@
   (testing "CP7: after lease transfer, new owner catches up from last checkpoint"
     (let [{:keys [store cleanup]} (make-env)
           tenant-1 (uuid/v4)
-          processor-name :test/catchup-proc
-          events-1 (mapv #(es/->event {:type :test/domain-event :body {:n %}}) (range 1 6))]
+          processor-name :test/catchup-proc]
       (try
-        (es/append store {:tenant-id tenant-1 :events events-1})
-        ;; Node A processes events 1-5
-        (let [handler (fn [_] {})]
-          (doseq [event events-1]
-            (tp/process-event
-              {:event event :handler-fn handler :event-store store
-               :tenant-id tenant-1 :processor-name processor-name})))
+        (let [events-1 (es/append store
+                         {:tenant-id tenant-1
+                          :events (mapv #(es/->event
+                                          {:type :test/domain-event :body {:n %}})
+                                        (range 1 6))})]
+          ;; Node A processes events 1-5
+          (let [handler (fn [_] {})]
+            (doseq [event events-1]
+              (tp/process-event
+                {:event event :handler-fn handler :event-store store
+                 :tenant-id tenant-1 :processor-name processor-name}))))
         ;; Append 5 more events (simulating events during lease transfer)
         (let [events-2 (mapv #(es/->event {:type :test/domain-event :body {:n %}}) (range 6 11))]
           (es/append store {:tenant-id tenant-1 :events events-2})

--- a/components/event-store-postgres-v2/event-store-postgres-v2.allium
+++ b/components/event-store-postgres-v2/event-store-postgres-v2.allium
@@ -20,7 +20,7 @@
 --
 -- Includes (the guarantees the code and tests actually prove):
 --   - total ordering: every event has a time-ordered identity, and reads
---     return events in that single global order, append order preserved
+--     return events in that single global order regardless of append order
 --   - atomic batch append: a batch is stored all-or-nothing under a global
 --     write lock, so concurrent appends serialise and never interleave
 --   - a synthesised transaction-marker event per append, recording exactly the
@@ -142,8 +142,8 @@ contract EventAppend {
     @invariant SerialisedWrites
         -- Appends are totally serialised: a single global write lock orders
         -- them, so two concurrent appends never interleave their events and
-        -- every appended event lands. The order in which events were appended
-        -- is preserved in the stream's total order.
+        -- every appended event lands. Serialization governs atomic visibility;
+        -- event identity, not append position, defines read order.
 
     @invariant TransactionMarker
         -- Each append also records exactly one transaction-marker event naming
@@ -180,7 +180,8 @@ contract EventRead {
     @invariant TotalOrderByIdentity
         -- Read results are ordered by event identity, which is the single total
         -- order the store imposes. An empty query reads the whole stream in that
-        -- order; any filter reads the matching subset in the same relative order.
+        -- order; any filter reads the matching subset in the same relative order,
+        -- even when append order differs from identity order.
 
     @invariant FilteringIsConjunctive
         -- Within one query the filters combine conjunctively: an event is

--- a/components/event-store-postgres-v2/test/ai/obney/grain/event_store_postgres_v2/integration_test.clj
+++ b/components/event-store-postgres-v2/test/ai/obney/grain/event_store_postgres_v2/integration_test.clj
@@ -7,7 +7,8 @@
             [next.jdbc :as jdbc]
             [next.jdbc.result-set :as rs]
             [clj-uuid :as uuid])
-  (:import [java.sql Timestamp]))
+  (:import [java.sql Timestamp]
+           [java.util UUID]))
 
 ;; -------------------- ;;
 ;; Schema Registration  ;;
@@ -359,6 +360,22 @@
                              (uuid/= a b) 0
                              :else 1))
                      ids)))))
+
+(deftest single-and-batch-reads-order-by-id-not-append-position
+  (let [tag-id (uuid/v4)
+        low (assoc (es/->event {:type :test/alpha :tags #{[:order tag-id]} :body {:n 1}})
+                   :event/id (UUID/fromString "01900000-0000-7000-8000-000000000001"))
+        high (assoc (es/->event {:type :test/alpha :tags #{[:order tag-id]} :body {:n 2}})
+                    :event/id (UUID/fromString "01900000-0000-7000-8000-000000000002"))]
+    (es/append *event-store* {:events [high]})
+    (es/append *event-store* {:events [low]})
+    (let [single (non-tx-events (read-events {:types #{:test/alpha}}))
+          batch (non-tx-events
+                 (read-events [{:types #{:test/alpha}}
+                               {:tags #{[:order tag-id]}}]))
+          expected [(:event/id low) (:event/id high)]]
+      (is (= expected (mapv :event/id single)))
+      (is (= expected (mapv :event/id batch))))))
 
 (deftest batch-empty-result
   (let [events (non-tx-events

--- a/components/event-store-postgres-v3/event-store-postgres-v3.allium
+++ b/components/event-store-postgres-v3/event-store-postgres-v3.allium
@@ -32,7 +32,7 @@
 --   - the body serialization format (Fressian) and the tag/type wire encoding;
 --     captured only as the Roundtrip guarantee, not the byte layout
 --   - UUID-v7 as the concrete ordered-id scheme; modelled as an abstract
---     stream position that is monotonic in append order
+--     stream position whose total order is independent of append order
 --   - logging, tracing and metrics
 --
 -- The conformance points below correspond to the component's test suite
@@ -71,13 +71,13 @@ external entity Tenant {
 -- Value Types
 ------------------------------------------------------------
 
--- A position within a tenant's stream. Positions are totally ordered and
--- strictly increasing in append order, so "later in the stream" is "greater
+-- A position within a tenant's stream. Positions are totally ordered by event
+-- identity independently of append order, so "later in a read" is "greater
 -- position". Used as event identity, as the read window bounds (after / as_of)
 -- and as the durable per-tenant watermark. The concrete scheme (a time-ordered
--- UUID) is an implementation detail; what matters is the total order.
+-- UUID) is an implementation detail; what matters is the identity-defined order.
 value Position {
-    -- The ordinal of this position in append order. Strictly increasing.
+    -- The ordinal of this position in the identity-defined stream order.
     ordinal: Integer
 }
 
@@ -200,14 +200,16 @@ contract StreamReader {
         -- A read returns exactly the tenant's events satisfying the filter — by
         -- tag membership, by type, and by an open position window (strictly
         -- after a lower bound, at-or-before an upper bound) — in ascending
-        -- position order. An empty match yields an empty stream. Two reads with
-        -- the same filter return the same events.
+        -- position order, even when append order differs from position order.
+        -- An empty match yields an empty stream. Two reads with the same filter
+        -- return the same events.
 
     @invariant ReverseAndLimitSeekNewest
         -- A reversed read returns matches in descending position order; combined
         -- with a limit it yields the newest matching events (e.g. reverse with
         -- limit one yields the single newest match). A limit without reverse
-        -- yields the oldest matches. Direction and limit apply to single reads.
+        -- yields the oldest matches. Ordering precedes limiting. Direction and
+        -- limit apply to single reads.
 
     @invariant BatchMergesAndDeduplicates
         -- A batch read returns the union of its filters' matches, with each
@@ -482,9 +484,8 @@ surface EventRead {
 
     @guarantee StreamOrdered
         -- Events are read in stream order: ascending position by default,
-        -- descending when reversed. Within a tenant this order matches the order
-        -- in which the events were appended, so replaying the stream reconstructs
-        -- state deterministically.
+        -- descending when reversed, regardless of storage insertion or append
+        -- order. Limits are applied after that ordering is established.
 
     @guarantee ReadIsTenantScoped
         -- A read returns only the events of its own tenant. One tenant's events

--- a/components/event-store-postgres-v3/event-store-postgres-v3.allium
+++ b/components/event-store-postgres-v3/event-store-postgres-v3.allium
@@ -128,8 +128,8 @@ value CasGuard {
 ------------------------------------------------------------
 
 -- Faithful round-tripping of an event across a durable write and read. The store
--- DEMANDS that whatever it persists, it returns unchanged: identity, type, tags,
--- timestamp and an arbitrary structured body survive a write/read cycle intact.
+-- DEMANDS that whatever it persists, it returns unchanged: store-assigned
+-- identity and timestamp plus type, tags and arbitrary body survive a read cycle.
 -- This is the serialization guarantee, stated behaviourally and independently of
 -- the encoding used.
 contract EventCodec {
@@ -181,6 +181,12 @@ contract AppendWriter {
         -- Concurrent appends to one tenant are serialized so each observes a
         -- settled stream and none is lost; appends to different tenants proceed
         -- independently.
+
+    @invariant StoreOwnsPersistenceEnvelope
+        -- Submitted domain events carry neither position nor timestamp. After a
+        -- guard accepts, the store assigns ordered UUID-v7 positions and one
+        -- shared recorded-at timestamp to the complete atomic unit. Supplying
+        -- either field is rejected rather than preserved or overwritten.
 }
 
 -- Ordered, filtered, streaming reads of a tenant's committed events. The store
@@ -274,8 +280,8 @@ entity Event {
     kind: DomainEvent | TransactionMarker
 }
 
--- A caller-supplied fact: an application event with a type and an arbitrary
--- structured body. These are the events domain logic appends and reads back.
+-- A caller-supplied fact: an application event with a type and arbitrary body.
+-- Position and timestamp are absent at submission and assigned by the store.
 variant DomainEvent : Event {
     -- The event's type, used both to interpret its body and to filter reads.
     event_type: String
@@ -321,8 +327,12 @@ rule AppendEvents {
     when: AppendRequested(tenant, events, metadata?)
 
     ensures:
+        let append_time = now
+        for event in events:
+            event.timestamp = append_time
         let marker = TransactionMarker.created(
             tenant: tenant,
+            timestamp: append_time,
             committed: events.position,
             metadata: metadata
         )

--- a/components/event-store-postgres-v3/src/ai/obney/grain/event_store_postgres_v3/core.clj
+++ b/components/event-store-postgres-v3/src/ai/obney/grain/event_store_postgres_v3/core.clj
@@ -1,7 +1,7 @@
 (ns ai.obney.grain.event-store-postgres-v3.core
   (:refer-clojure :exclude [read])
   (:require [ai.obney.grain.event-store-v3.interface.protocol :as p :refer [EventStore start-event-store]]
-            [ai.obney.grain.event-store-v3.interface :refer [->event]]
+            [ai.obney.grain.event-store-v3.interface :refer [prepare-append]]
             [ai.obney.grain.event-store-postgres-v3.interface.datasource :as datasource]
             [ai.obney.grain.fressian-util.interface :as fressian-util]
             [next.jdbc :as jdbc]
@@ -293,36 +293,6 @@
                               tenant-id])
           :tenants/last_event_id))
 
-(defn- strictly-increasing-after?
-  [last-id events]
-  (reduce (fn [previous event]
-            (let [event-id (:event/id event)]
-              (if (and event-id
-                       (or (nil? previous) (uuid/< previous event-id)))
-                event-id
-                (reduced false))))
-          last-id
-          events))
-
-(defn- assign-commit-ordered-ids
-  "Preserve caller IDs when they are already beyond the committed tenant
-   watermark. Reassign the whole batch otherwise. Called only while holding
-   PostgreSQL's per-tenant advisory lock."
-  [last-id events]
-  (if (strictly-increasing-after? last-id events)
-    events
-    (loop [remaining events
-           previous last-id
-           assigned []]
-      (if-let [event (first remaining)]
-        (let [event-id (loop [candidate (uuid/v7)]
-                         (if (or (nil? previous) (uuid/< previous candidate))
-                           candidate
-                           (recur (uuid/v7))))]
-          (recur (next remaining) event-id
-                 (conj assigned (assoc event :event/id event-id))))
-        assigned))))
-
 (defn append
   [event-store {{:keys [predicate-fn] :as cas} :cas
                 :keys [tenant-id events tx-metadata]}]
@@ -334,19 +304,14 @@
       (jdbc/execute! conn ["SET LOCAL lock_timeout = '5000ms'"])
       (jdbc/execute! conn ["SELECT pg_advisory_xact_lock(?)" (tenant-lock-key tenant-id)])
       (let [last-id (committed-last-event-id conn tenant-id)
-            events (assign-commit-ordered-ids last-id events)
-            tx (->event
-                {:type :grain/tx
-                 :body (cond-> {:event-ids (set (mapv :event/id events))}
-                         tx-metadata (assoc :metadata tx-metadata))})
-            tx-events (assign-commit-ordered-ids (:event/id (last events)) [tx])
-            events* (into events tx-events)
-            max-event-id (:event/id (last events*))
-            upsert-tenant!
-            (fn []
-              (jdbc/execute! conn ["INSERT INTO grain.tenants (id, last_event_id) VALUES (?, ?)
-                                    ON CONFLICT (id) DO UPDATE SET last_event_id = ?"
-                                   tenant-id max-event-id max-event-id]))]
+            persist! (fn []
+                       (let [{:keys [events events-with-tx last-event-id]}
+                             (prepare-append last-id events tx-metadata)]
+                         (jdbc/execute! conn ["INSERT INTO grain.tenants (id, last_event_id) VALUES (?, ?)
+                                               ON CONFLICT (id) DO UPDATE SET last_event_id = ?"
+                                              tenant-id last-event-id last-event-id])
+                         (insert-events conn tenant-id events-with-tx)
+                         events))]
         ;; CAS check + insert. Tenant upsert (including last_event_id bump) runs
         ;; only on successful-insert branches.
         (if cas
@@ -369,19 +334,13 @@
                                             ::none plan)]
                                (if (= r ::none) (f) r))))]
             (if (predicate-fn cas-events)
-              (do
-                (upsert-tenant!)
-                (insert-events conn tenant-id events*)
-                events)
+              (persist!)
               (let [anomaly  {::anom/category ::anom/conflict
                               ::anom/message "CAS failed"
                               ::cas cas}]
                 (u/log ::cas-failed :anomaly anomaly)
                 anomaly)))
-          (do
-            (upsert-tenant!)
-            (insert-events conn tenant-id events*)
-            events)))))
+          (persist!)))))
 
 (defn tenants
   [event-store]

--- a/components/event-store-postgres-v3/src/ai/obney/grain/event_store_postgres_v3/core.clj
+++ b/components/event-store-postgres-v3/src/ai/obney/grain/event_store_postgres_v3/core.clj
@@ -9,7 +9,8 @@
             [integrant.core :as ig]
             [hikari-cp.core :as hikari]
             [cognitect.anomalies :as anom]
-            [clojure.string :as string]))
+            [clojure.string :as string]
+            [clj-uuid :as uuid]))
 
 ;; --------------------- ;;
 ;; Advisory Lock Mapping  ;;
@@ -285,34 +286,71 @@
         :event/tags))])
    {:batch-size 100}))
 
+(defn- committed-last-event-id
+  [conn tenant-id]
+  (some-> (jdbc/execute-one! conn
+                             ["SELECT last_event_id FROM grain.tenants WHERE id = ?"
+                              tenant-id])
+          :tenants/last_event_id))
+
+(defn- strictly-increasing-after?
+  [last-id events]
+  (reduce (fn [previous event]
+            (let [event-id (:event/id event)]
+              (if (and event-id
+                       (or (nil? previous) (uuid/< previous event-id)))
+                event-id
+                (reduced false))))
+          last-id
+          events))
+
+(defn- assign-commit-ordered-ids
+  "Preserve caller IDs when they are already beyond the committed tenant
+   watermark. Reassign the whole batch otherwise. Called only while holding
+   PostgreSQL's per-tenant advisory lock."
+  [last-id events]
+  (if (strictly-increasing-after? last-id events)
+    events
+    (loop [remaining events
+           previous last-id
+           assigned []]
+      (if-let [event (first remaining)]
+        (let [event-id (loop [candidate (uuid/v7)]
+                         (if (or (nil? previous) (uuid/< previous candidate))
+                           candidate
+                           (recur (uuid/v7))))]
+          (recur (next remaining) event-id
+                 (conj assigned (assoc event :event/id event-id))))
+        assigned))))
+
 (defn append
   [event-store {{:keys [predicate-fn] :as cas} :cas
                 :keys [tenant-id events tx-metadata]}]
-  (let [events* (conj
-                 events
-                 (->event
-                  {:type :grain/tx
-                   :body (cond-> {:event-ids (set (mapv :event/id events))}
-                           tx-metadata (assoc :metadata tx-metadata))}))
-        max-event-id (:event/id (last events*))
-        upsert-tenant!
-        (fn [conn]
-          (jdbc/execute! conn ["INSERT INTO grain.tenants (id, last_event_id) VALUES (?, ?)
-                                ON CONFLICT (id) DO UPDATE SET last_event_id = ?"
-                               tenant-id max-event-id max-event-id]))]
-    (jdbc/with-transaction
-      [conn (get-in event-store [:state ::connection-pool])]
+  (jdbc/with-transaction
+    [conn (get-in event-store [:state ::connection-pool])]
       ;; Set tenant context for RLS
       (jdbc/execute! conn [(str "SET LOCAL app.tenant_id = '" (str tenant-id) "'")])
       ;; Per-tenant advisory lock
       (jdbc/execute! conn ["SET LOCAL lock_timeout = '5000ms'"])
       (jdbc/execute! conn ["SELECT pg_advisory_xact_lock(?)" (tenant-lock-key tenant-id)])
-      ;; CAS check + insert. Tenant upsert (including last_event_id bump) runs
-      ;; only on the successful-insert branches so last_event_id strictly
-      ;; reflects events actually inserted; a CAS failure must not leave a
-      ;; phantom watermark.
-      (if cas
-        (let [cas-query (assoc cas :tenant-id tenant-id)
+      (let [last-id (committed-last-event-id conn tenant-id)
+            events (assign-commit-ordered-ids last-id events)
+            tx (->event
+                {:type :grain/tx
+                 :body (cond-> {:event-ids (set (mapv :event/id events))}
+                         tx-metadata (assoc :metadata tx-metadata))})
+            tx-events (assign-commit-ordered-ids (:event/id (last events)) [tx])
+            events* (into events tx-events)
+            max-event-id (:event/id (last events*))
+            upsert-tenant!
+            (fn []
+              (jdbc/execute! conn ["INSERT INTO grain.tenants (id, last_event_id) VALUES (?, ?)
+                                    ON CONFLICT (id) DO UPDATE SET last_event_id = ?"
+                                   tenant-id max-event-id max-event-id]))]
+        ;; CAS check + insert. Tenant upsert (including last_event_id bump) runs
+        ;; only on successful-insert branches.
+        (if cas
+          (let [cas-query (assoc cas :tenant-id tenant-id)
               {:keys [where-sql params]} (build-single-query-sql cas-query)
               {ol-sql :sql ol-params :params} (order-limit-clause cas-query)
               sql (str "SELECT id, time, type, tags, data FROM grain.events "
@@ -330,18 +368,20 @@
                                                 (f acc (transform-row row))))
                                             ::none plan)]
                                (if (= r ::none) (f) r))))]
-          (if (predicate-fn cas-events)
-            (do
-              (upsert-tenant! conn)
-              (insert-events conn tenant-id events*))
-            (let [anomaly  {::anom/category ::anom/conflict
-                            ::anom/message "CAS failed"
-                            ::cas cas}]
-              (u/log ::cas-failed :anomaly anomaly)
-              anomaly)))
-        (do
-          (upsert-tenant! conn)
-          (insert-events conn tenant-id events*))))))
+            (if (predicate-fn cas-events)
+              (do
+                (upsert-tenant!)
+                (insert-events conn tenant-id events*)
+                events)
+              (let [anomaly  {::anom/category ::anom/conflict
+                              ::anom/message "CAS failed"
+                              ::cas cas}]
+                (u/log ::cas-failed :anomaly anomaly)
+                anomaly)))
+          (do
+            (upsert-tenant!)
+            (insert-events conn tenant-id events*)
+            events)))))
 
 (defn tenants
   [event-store]

--- a/components/event-store-postgres-v3/src/ai/obney/grain/event_store_postgres_v3/core.clj
+++ b/components/event-store-postgres-v3/src/ai/obney/grain/event_store_postgres_v3/core.clj
@@ -1,7 +1,7 @@
 (ns ai.obney.grain.event-store-postgres-v3.core
   (:refer-clojure :exclude [read])
   (:require [ai.obney.grain.event-store-v3.interface.protocol :as p :refer [EventStore start-event-store]]
-            [ai.obney.grain.event-store-v3.interface :refer [prepare-append]]
+            [ai.obney.grain.event-store-v3.interface.backend :refer [prepare-append]]
             [ai.obney.grain.event-store-postgres-v3.interface.datasource :as datasource]
             [ai.obney.grain.fressian-util.interface :as fressian-util]
             [next.jdbc :as jdbc]

--- a/components/event-store-postgres-v3/test/ai/obney/grain/event_store_postgres_v3/integration_test.clj
+++ b/components/event-store-postgres-v3/test/ai/obney/grain/event_store_postgres_v3/integration_test.clj
@@ -7,7 +7,8 @@
             [next.jdbc :as jdbc]
             [next.jdbc.result-set :as rs]
             [clj-uuid :as uuid])
-  (:import [java.time OffsetDateTime]))
+  (:import [java.time OffsetDateTime]
+           [java.util UUID]))
 
 ;; -------------------- ;;
 ;; Schema Registration  ;;
@@ -408,6 +409,27 @@
                              (uuid/= a b) 0
                              :else 1))
                      ids)))))
+
+(deftest commit-order-is-established-before-reversing-or-limiting-pg
+  (let [tag-id (uuid/v4)
+        low (assoc (es/->event {:type :test/alpha :tags #{[:order tag-id]} :body {:n 1}})
+                   :event/id (UUID/fromString "01900000-0000-7000-8000-000000000001"))
+        high (assoc (es/->event {:type :test/alpha :tags #{[:order tag-id]} :body {:n 2}})
+                    :event/id (UUID/fromString "01900000-0000-7000-8000-000000000002"))]
+    (let [[persisted-high] (es/append *event-store* {:tenant-id *tenant-id* :events [high]})
+          [persisted-low] (es/append *event-store* {:tenant-id *tenant-id* :events [low]})
+          expected [(:event/id persisted-high) (:event/id persisted-low)]
+          ids #(mapv :event/id (read-events %))]
+      (is (= expected (ids {:types #{:test/alpha}})))
+      (is (= expected
+             (ids [{:types #{:test/alpha}}
+                   {:tags #{[:order tag-id]}}])))
+      (is (= (vec (reverse expected))
+             (ids {:types #{:test/alpha} :reverse? true})))
+      (is (= [(:event/id persisted-high)]
+             (ids {:types #{:test/alpha} :limit 1})))
+      (is (= [(:event/id persisted-low)]
+             (ids {:types #{:test/alpha} :reverse? true :limit 1}))))))
 
 (deftest batch-empty-result
   (let [events (non-tx-events

--- a/components/event-store-postgres-v3/test/ai/obney/grain/event_store_postgres_v3/integration_test.clj
+++ b/components/event-store-postgres-v3/test/ai/obney/grain/event_store_postgres_v3/integration_test.clj
@@ -70,13 +70,11 @@
   ([type tags body]
    (let [event (es/->event (cond-> {:type type :tags tags}
                              body (assoc :body body)))]
-     (es/append *event-store* {:tenant-id *tenant-id* :events [event]})
-     event)))
+     (first (es/append *event-store* {:tenant-id *tenant-id* :events [event]})))))
 
 (defn append-events! [events-data]
   (let [events (mapv es/->event events-data)]
-    (es/append *event-store* {:tenant-id *tenant-id* :events events})
-    events))
+    (es/append *event-store* {:tenant-id *tenant-id* :events events})))
 
 (defn read-events [args]
   (into [] (es/read *event-store* (if (vector? args)
@@ -247,9 +245,9 @@
 
 (deftest events-with-empty-body
   (let [event (es/->event {:type :test/alpha :tags #{}})
-        _ (es/append *event-store* {:tenant-id *tenant-id* :events [event]})
+        [persisted] (es/append *event-store* {:tenant-id *tenant-id* :events [event]})
         read (first (non-tx-events (read-events {})))]
-    (is (= (:event/id event) (:event/id read)))
+    (is (= (:event/id persisted) (:event/id read)))
     (is (= :test/alpha (:event/type read)))))
 
 ;; ============================ ;;
@@ -412,13 +410,11 @@
 
 (deftest commit-order-is-established-before-reversing-or-limiting-pg
   (let [tag-id (uuid/v4)
-        low (assoc (es/->event {:type :test/alpha :tags #{[:order tag-id]} :body {:n 1}})
-                   :event/id (UUID/fromString "01900000-0000-7000-8000-000000000001"))
-        high (assoc (es/->event {:type :test/alpha :tags #{[:order tag-id]} :body {:n 2}})
-                    :event/id (UUID/fromString "01900000-0000-7000-8000-000000000002"))]
-    (let [[persisted-high] (es/append *event-store* {:tenant-id *tenant-id* :events [high]})
-          [persisted-low] (es/append *event-store* {:tenant-id *tenant-id* :events [low]})
-          expected [(:event/id persisted-high) (:event/id persisted-low)]
+        first-event (es/->event {:type :test/alpha :tags #{[:order tag-id]} :body {:n 2}})
+        second-event (es/->event {:type :test/alpha :tags #{[:order tag-id]} :body {:n 1}})]
+    (let [[persisted-first] (es/append *event-store* {:tenant-id *tenant-id* :events [first-event]})
+          [persisted-second] (es/append *event-store* {:tenant-id *tenant-id* :events [second-event]})
+          expected [(:event/id persisted-first) (:event/id persisted-second)]
           ids #(mapv :event/id (read-events %))]
       (is (= expected (ids {:types #{:test/alpha}})))
       (is (= expected
@@ -426,9 +422,9 @@
                    {:tags #{[:order tag-id]}}])))
       (is (= (vec (reverse expected))
              (ids {:types #{:test/alpha} :reverse? true})))
-      (is (= [(:event/id persisted-high)]
+      (is (= [(:event/id persisted-first)]
              (ids {:types #{:test/alpha} :limit 1})))
-      (is (= [(:event/id persisted-low)]
+      (is (= [(:event/id persisted-second)]
              (ids {:types #{:test/alpha} :reverse? true :limit 1}))))))
 
 (deftest batch-empty-result
@@ -654,13 +650,19 @@
 
 (deftest timestamp-preserved-as-offsetdatetime
   (let [before (OffsetDateTime/now)
-        _ (append-event! :test/alpha #{} {:n 1})
+        submitted [(es/->event {:type :test/alpha :tags #{} :body {:n 1}})
+                   (es/->event {:type :test/beta :tags #{} :body {:n 2}})]
+        returned (es/append *event-store* {:tenant-id *tenant-id* :events submitted})
         after (OffsetDateTime/now)
-        read (first (non-tx-events (read-events {})))
-        ts (:event/timestamp read)]
+        stored (read-events {})
+        timestamps (mapv :event/timestamp stored)
+        ts (first timestamps)]
     (is (instance? OffsetDateTime ts))
     (is (not (.isBefore ts before)))
-    (is (not (.isAfter ts after)))))
+    (is (not (.isAfter ts after)))
+    (is (apply = timestamps))
+    (is (= (mapv :event/timestamp returned)
+           (mapv :event/timestamp (non-tx-events stored))))))
 
 ;; ======================================== ;;
 ;; J. Tenant Isolation (5 tests)            ;;

--- a/components/event-store-sqlite-v3/event-store-sqlite-v3.allium
+++ b/components/event-store-sqlite-v3/event-store-sqlite-v3.allium
@@ -128,10 +128,10 @@ contract EventLog {
     read_stream: (tenant: Tenant, filter: ReadQuery) -> Sequence<Event>
 
     @invariant TimeOrdered
-        -- Events are positioned by a time-ordered identity (UUID v7), so the
-        -- order in which they were appended is the order in which they read
-        -- back. A read streams ascending by id by default; a reverse read
-        -- streams descending. Ordering is per tenant.
+        -- Events are positioned by a time-ordered identity (UUID v7). A read
+        -- streams ascending by id by default even when append order differs;
+        -- a reverse read streams descending. Ordering is per tenant and is
+        -- established before any limit is applied.
 
     @invariant AppendOnly
         -- Committed events are immutable facts. The store only ever appends; it
@@ -496,10 +496,11 @@ surface EventRead {
         demands EventCodec
 
     @guarantee OrderedAndTenantScoped
-        -- A read returns this tenant's matching events in time order (ascending
-        -- by default, descending on a reverse read), reconstructed faithfully
-        -- from storage, and never includes any other tenant's events. A batch
-        -- read merges its filters and deduplicates by id.
+        -- A read returns this tenant's matching events in id order regardless of
+        -- append position (ascending by default, descending on a reverse read),
+        -- reconstructed faithfully from storage, and never includes any other
+        -- tenant's events. Ordering precedes limiting. A batch read merges its
+        -- filters and deduplicates by id.
 
     @guarantee NewestRetrievedDirectly
         -- Fetching the newest matching event(s) — a reverse read with a small

--- a/components/event-store-sqlite-v3/event-store-sqlite-v3.allium
+++ b/components/event-store-sqlite-v3/event-store-sqlite-v3.allium
@@ -92,10 +92,9 @@ value ReadQuery {
 -- Contracts
 ------------------------------------------------------------
 
--- The faithful round-trip obligation. An event carries an identity, a type, a
--- timestamp, a set of tags and an arbitrary structured body; all of it must come
--- back out byte-faithful to what went in. This is a property of the encode/decode
--- pair, not of stored entity state, so it lives as a contract invariant.
+-- The faithful round-trip obligation begins after the store assigns the event's
+-- persistence envelope. Identity, recorded-at timestamp, type, tags and body
+-- must then come back out byte-faithful to what was committed.
 contract EventCodec {
     -- Persist an event's body, tags and metadata for later reconstruction.
     encode: (event: Event) -> ByteArray
@@ -208,9 +207,9 @@ entity Tenant {
     domain_events: events where is_transaction_marker = false
 }
 
--- A single immutable fact in one tenant's stream. Its id is a time-ordered
--- identity assigned before it reaches the store; that identity fixes both the
--- event's uniqueness within its tenant and its position in the ordered stream.
+-- A single immutable fact in one tenant's stream. The store assigns its id and
+-- timestamp inside the tenant-serialized append; the id fixes uniqueness and
+-- position in the ordered stream.
 -- An event carries zero or more tags (entity references it concerns) and an
 -- arbitrary body, both opaque to the store.
 entity Event {
@@ -218,8 +217,8 @@ entity Event {
     id: String
     -- Owning tenant. Reads and appends are confined to a single tenant.
     tenant: Tenant
-    -- When the fact occurred, as recorded by its producer. Preserved exactly,
-    -- including a non-UTC offset.
+    -- When the store recorded the atomic append. Every domain event and marker
+    -- in one append shares this value.
     timestamp: Timestamp
     -- The event's kind. May be a simple or qualified name; round-trips exactly.
     event_type: String
@@ -266,13 +265,16 @@ rule AppendTransaction {
     when: AppendEvents(tenant, events, tx_metadata?)
 
     ensures:
+        let append_time = now
         let marker = Event.created(
             tenant: tenant,
             event_type: "grain/tx",
+            timestamp: append_time,
             is_transaction_marker: true
         )
         for event in events:
             event.tenant = tenant
+            event.timestamp = append_time
         Transaction.created(
             tenant: tenant,
             marker: marker,
@@ -386,11 +388,10 @@ invariant EventsBelongToOneTenant {
 -- The store's authoritative order within a tenant is event id order. The store
 -- reads events back in id order and treats that as the stream's total order (see
 -- EventLog.TimeOrdered). It relies on ids being UUID v7 (time-ordered) so that id
--- order approximates chronological order, but it does not itself mint ids or
--- timestamps and does not enforce any relationship between an event's id and its
--- producer-supplied timestamp; under cross-node clock skew a larger id may carry
--- an earlier timestamp (see open questions). The guarantee the store makes is the
--- id ordering itself, captured as EventLog.TimeOrdered, not a timestamp coupling.
+-- order approximates chronological order. The store mints ids and one timestamp
+-- per append after tenant serialization. Cross-node wall-clock skew can still
+-- make timestamps non-monotonic across appends, so id ordering remains the sole
+-- authoritative stream order captured by EventLog.TimeOrdered.
 
 -- A transaction marker's committed-id set never includes the marker itself: the
 -- marker records the domain events of its append, not its own id.

--- a/components/event-store-sqlite-v3/src/ai/obney/grain/event_store_sqlite_v3/core.clj
+++ b/components/event-store-sqlite-v3/src/ai/obney/grain/event_store_sqlite_v3/core.clj
@@ -1,7 +1,7 @@
 (ns ai.obney.grain.event-store-sqlite-v3.core
   (:refer-clojure :exclude [read])
   (:require [ai.obney.grain.event-store-v3.interface.protocol :as p :refer [EventStore start-event-store]]
-            [ai.obney.grain.event-store-v3.interface :refer [->event]]
+            [ai.obney.grain.event-store-v3.interface :refer [prepare-append]]
             [ai.obney.grain.event-store-sqlite-v3.interface.datasource :as datasource]
             [ai.obney.grain.fressian-util.interface :as fressian-util]
             [next.jdbc :as jdbc]
@@ -296,36 +296,6 @@
           :tenants/last_event_id
           UUID/fromString))
 
-(defn- strictly-increasing-after?
-  [last-id events]
-  (reduce (fn [previous event]
-            (let [event-id (:event/id event)]
-              (if (and event-id
-                       (or (nil? previous) (uuid/< previous event-id)))
-                event-id
-                (reduced false))))
-          last-id
-          events))
-
-(defn- assign-commit-ordered-ids
-  "Preserve caller IDs when they are already beyond the committed tenant
-   watermark. Reassign the whole batch otherwise. Called only while holding
-   SQLite's tenant-serializing write transaction."
-  [last-id events]
-  (if (strictly-increasing-after? last-id events)
-    events
-    (loop [remaining events
-           previous last-id
-           assigned []]
-      (if-let [event (first remaining)]
-        (let [event-id (loop [candidate (uuid/v7)]
-                         (if (or (nil? previous) (uuid/< previous candidate))
-                           candidate
-                           (recur (uuid/v7))))]
-          (recur (next remaining) event-id
-                 (conj assigned (assoc event :event/id event-id))))
-        assigned))))
-
 (defn- with-immediate-tx
   "Run body-fn inside a BEGIN IMMEDIATE transaction on a fresh connection.
    body-fn receives the connection and returns its result.
@@ -380,31 +350,23 @@
       pool
       (fn [conn]
         (let [last-id (committed-last-event-id conn tenant-id)
-              events (assign-commit-ordered-ids last-id events)
-              tx (->event
-                  {:type :grain/tx
-                   :body (cond-> {:event-ids (set (mapv :event/id events))}
-                           tx-metadata (assoc :metadata tx-metadata))})
-              events* (assign-commit-ordered-ids (:event/id (last events)) [tx])
-              events* (into events events*)
-              max-event-id (:event/id (last events*))]
+              persist! (fn []
+                         (let [{:keys [events events-with-tx last-event-id]}
+                               (prepare-append last-id events tx-metadata)]
+                           (upsert-tenant! conn tenant-id last-event-id)
+                           (insert-events! conn tenant-id events-with-tx)
+                           events))]
           (if cas
             (let [{:keys [sql params]} (build-single-query (assoc cas :tenant-id tenant-id))
                   cas-events (conn-reducible conn sql params)]
               (if (predicate-fn cas-events)
-                (do
-                  (upsert-tenant! conn tenant-id max-event-id)
-                  (insert-events! conn tenant-id events*)
-                  events)
+                (persist!)
                 (let [anomaly {::anom/category ::anom/conflict
                                ::anom/message "CAS failed"
                                ::cas cas}]
                   (u/log ::cas-failed :anomaly anomaly)
                   anomaly)))
-            (do
-              (upsert-tenant! conn tenant-id max-event-id)
-              (insert-events! conn tenant-id events*)
-              events)))))))
+            (persist!)))))))
 
 ;; ----------- ;;
 ;; Tenants     ;;

--- a/components/event-store-sqlite-v3/src/ai/obney/grain/event_store_sqlite_v3/core.clj
+++ b/components/event-store-sqlite-v3/src/ai/obney/grain/event_store_sqlite_v3/core.clj
@@ -1,7 +1,7 @@
 (ns ai.obney.grain.event-store-sqlite-v3.core
   (:refer-clojure :exclude [read])
   (:require [ai.obney.grain.event-store-v3.interface.protocol :as p :refer [EventStore start-event-store]]
-            [ai.obney.grain.event-store-v3.interface :refer [prepare-append]]
+            [ai.obney.grain.event-store-v3.interface.backend :refer [prepare-append]]
             [ai.obney.grain.event-store-sqlite-v3.interface.datasource :as datasource]
             [ai.obney.grain.fressian-util.interface :as fressian-util]
             [next.jdbc :as jdbc]

--- a/components/event-store-sqlite-v3/src/ai/obney/grain/event_store_sqlite_v3/core.clj
+++ b/components/event-store-sqlite-v3/src/ai/obney/grain/event_store_sqlite_v3/core.clj
@@ -9,7 +9,8 @@
             [integrant.core :as ig]
             [hikari-cp.core :as hikari]
             [cognitect.anomalies :as anom]
-            [clojure.string :as string])
+            [clojure.string :as string]
+            [clj-uuid :as uuid])
   (:import [java.time OffsetDateTime]
            [java.util UUID]
            [java.sql Connection]))
@@ -287,6 +288,44 @@
                    ON CONFLICT(id) DO UPDATE SET last_event_id = excluded.last_event_id"
                   (str tenant-id) (str last-event-id)]))
 
+(defn- committed-last-event-id
+  [conn tenant-id]
+  (some-> (jdbc/execute-one! conn
+                             ["SELECT last_event_id FROM tenants WHERE id = ?"
+                              (str tenant-id)])
+          :tenants/last_event_id
+          UUID/fromString))
+
+(defn- strictly-increasing-after?
+  [last-id events]
+  (reduce (fn [previous event]
+            (let [event-id (:event/id event)]
+              (if (and event-id
+                       (or (nil? previous) (uuid/< previous event-id)))
+                event-id
+                (reduced false))))
+          last-id
+          events))
+
+(defn- assign-commit-ordered-ids
+  "Preserve caller IDs when they are already beyond the committed tenant
+   watermark. Reassign the whole batch otherwise. Called only while holding
+   SQLite's tenant-serializing write transaction."
+  [last-id events]
+  (if (strictly-increasing-after? last-id events)
+    events
+    (loop [remaining events
+           previous last-id
+           assigned []]
+      (if-let [event (first remaining)]
+        (let [event-id (loop [candidate (uuid/v7)]
+                         (if (or (nil? previous) (uuid/< previous candidate))
+                           candidate
+                           (recur (uuid/v7))))]
+          (recur (next remaining) event-id
+                 (conj assigned (assoc event :event/id event-id))))
+        assigned))))
+
 (defn- with-immediate-tx
   "Run body-fn inside a BEGIN IMMEDIATE transaction on a fresh connection.
    body-fn receives the connection and returns its result.
@@ -336,32 +375,36 @@
 (defn append
   [event-store {{:keys [predicate-fn] :as cas} :cas
                 :keys [tenant-id events tx-metadata]}]
-  (let [events* (conj
-                 events
-                 (->event
-                  {:type :grain/tx
-                   :body (cond-> {:event-ids (set (mapv :event/id events))}
-                           tx-metadata (assoc :metadata tx-metadata))}))
-        max-event-id (:event/id (last events*))
-        pool (get-in event-store [:state ::connection-pool])]
+  (let [pool (get-in event-store [:state ::connection-pool])]
     (with-immediate-tx
       pool
       (fn [conn]
-        (if cas
-          (let [{:keys [sql params]} (build-single-query (assoc cas :tenant-id tenant-id))
-                cas-events (conn-reducible conn sql params)]
-            (if (predicate-fn cas-events)
-              (do
-                (upsert-tenant! conn tenant-id max-event-id)
-                (insert-events! conn tenant-id events*))
-              (let [anomaly {::anom/category ::anom/conflict
-                             ::anom/message "CAS failed"
-                             ::cas cas}]
-                (u/log ::cas-failed :anomaly anomaly)
-                anomaly)))
-          (do
-            (upsert-tenant! conn tenant-id max-event-id)
-            (insert-events! conn tenant-id events*)))))))
+        (let [last-id (committed-last-event-id conn tenant-id)
+              events (assign-commit-ordered-ids last-id events)
+              tx (->event
+                  {:type :grain/tx
+                   :body (cond-> {:event-ids (set (mapv :event/id events))}
+                           tx-metadata (assoc :metadata tx-metadata))})
+              events* (assign-commit-ordered-ids (:event/id (last events)) [tx])
+              events* (into events events*)
+              max-event-id (:event/id (last events*))]
+          (if cas
+            (let [{:keys [sql params]} (build-single-query (assoc cas :tenant-id tenant-id))
+                  cas-events (conn-reducible conn sql params)]
+              (if (predicate-fn cas-events)
+                (do
+                  (upsert-tenant! conn tenant-id max-event-id)
+                  (insert-events! conn tenant-id events*)
+                  events)
+                (let [anomaly {::anom/category ::anom/conflict
+                               ::anom/message "CAS failed"
+                               ::cas cas}]
+                  (u/log ::cas-failed :anomaly anomaly)
+                  anomaly)))
+            (do
+              (upsert-tenant! conn tenant-id max-event-id)
+              (insert-events! conn tenant-id events*)
+              events)))))))
 
 ;; ----------- ;;
 ;; Tenants     ;;

--- a/components/event-store-sqlite-v3/test/ai/obney/grain/event_store_sqlite_v3/append_throughput_test.clj
+++ b/components/event-store-sqlite-v3/test/ai/obney/grain/event_store_sqlite_v3/append_throughput_test.clj
@@ -1,0 +1,204 @@
+(ns ai.obney.grain.event-store-sqlite-v3.append-throughput-test
+  "Correctness-first SQLite append load tests. Timing is diagnostic only."
+  (:require [clojure.test :refer :all]
+            [ai.obney.grain.event-store-v3.interface :as es]
+            [ai.obney.grain.event-store-sqlite-v3.interface]
+            [ai.obney.grain.schema-util.interface :refer [defschemas]]
+            [clj-uuid :as uuid])
+  (:import [java.io File]
+           [java.util.concurrent CountDownLatch TimeUnit]))
+
+(defschemas append-throughput-schemas
+  {:throughput/event [:map
+                      [:writer :int]
+                      [:n :int]]})
+
+(defn- delete-db-files! [path]
+  (doseq [suffix ["" "-wal" "-shm" "-journal"]]
+    (.delete (File. (str path suffix)))))
+
+(defn- with-store [f]
+  (let [tmp (File/createTempFile "grain-append-throughput-" ".sqlite")
+        path (.getAbsolutePath tmp)]
+    (.delete tmp)
+    (let [store (es/start {:conn {:type :sqlite :database-file path}})]
+      (try (f store)
+           (finally
+             (es/stop store)
+             (delete-db-files! path))))))
+
+(defn- percentile [values p]
+  (when (seq values)
+    (let [sorted (vec (sort values))
+          index (min (dec (count sorted))
+                     (long (Math/ceil (* p (count sorted)))))]
+      (nth sorted (max 0 (dec index))))))
+
+(defn- print-metrics! [label elapsed-ns latencies-ns]
+  (let [seconds (/ elapsed-ns 1.0e9)
+        millis #(when % (/ % 1.0e6))]
+    (println (format "%s: %.1f writes/s, p50=%.2fms p95=%.2fms p99=%.2fms"
+                     label
+                     (/ (count latencies-ns) seconds)
+                     (millis (percentile latencies-ns 0.50))
+                     (millis (percentile latencies-ns 0.95))
+                     (millis (percentile latencies-ns 0.99))))))
+
+(defn- run-load!
+  [store {:keys [writers appends-per-writer tenants timeout-ms]
+          :or {timeout-ms 30000}}]
+  (let [ready (CountDownLatch. writers)
+        start (CountDownLatch. 1)
+        results (atom [])
+        tasks (mapv
+               (fn [writer]
+                 (future
+                   (.countDown ready)
+                   (.await start)
+                   (dotimes [n appends-per-writer]
+                     (let [tenant-id (nth tenants (mod (+ writer n) (count tenants)))
+                           event (es/->event {:type :throughput/event
+                                             :body {:writer writer :n n}})
+                           before (System/nanoTime)
+                           returned (es/append store {:tenant-id tenant-id
+                                                      :events [event]})
+                           elapsed (- (System/nanoTime) before)]
+                       (swap! results conj {:tenant-id tenant-id
+                                            :returned returned
+                                            :latency-ns elapsed})))))
+               (range writers))
+        _ (.await ready 10 TimeUnit/SECONDS)
+        began (System/nanoTime)
+        _ (.countDown start)
+        deadline (+ (System/currentTimeMillis) timeout-ms)
+        completed? (every? true?
+                           (map (fn [task]
+                                  (let [remaining (max 1 (- deadline (System/currentTimeMillis)))]
+                                    (not= ::timeout (deref task remaining ::timeout))))
+                                tasks))
+        elapsed (- (System/nanoTime) began)]
+    (when-not completed? (run! future-cancel tasks))
+    {:completed? completed?
+     :elapsed-ns elapsed
+     :results @results
+     :latencies-ns (mapv :latency-ns @results)}))
+
+(defn- domain-events [store tenant-id]
+  (into []
+        (remove #(= :grain/tx (:event/type %)))
+        (es/read store {:tenant-id tenant-id})))
+
+(defn- strictly-increasing? [ids]
+  (every? true? (map uuid/< ids (rest ids))))
+
+(deftest concurrent-hot-tenant-appends-are-complete-and-ordered
+  (with-store
+    (fn [store]
+      (let [tenant-id (uuid/v4)
+            initial-watermark (get-in (es/tenants store) [tenant-id :tenant/last-event-id])
+            result (run-load! store {:writers 8 :appends-per-writer 100
+                                     :tenants [tenant-id] :timeout-ms 30000})
+            events (domain-events store tenant-id)
+            ids (mapv :event/id events)
+            returned (mapcat :returned (:results result))
+            watermark (get-in (es/tenants store) [tenant-id :tenant/last-event-id])]
+        (print-metrics! "SQLite hot tenant (8x100)" (:elapsed-ns result) (:latencies-ns result))
+        (is (:completed? result) "all writers complete within 30 seconds")
+        (is (= 800 (count (:results result))))
+        (is (= 800 (count returned)) "every append returns one persisted event")
+        (is (= 800 (count events)))
+        (is (= 800 (count (set ids))))
+        (is (strictly-increasing? ids))
+        (is (and watermark (or (nil? initial-watermark)
+                               (not (uuid/< watermark initial-watermark)))))
+        (is (not (uuid/< watermark (last ids))))))))
+
+(deftest reverse-id-groups-are-reassigned-under-load
+  (with-store
+    (fn [store]
+      (let [tenant-id (uuid/v4)
+            writers 8
+            groups-per-writer 25
+            ready (CountDownLatch. writers)
+            start (CountDownLatch. 1)
+            observations (atom [])
+            tasks (mapv
+                   (fn [writer]
+                     (future
+                       (.countDown ready)
+                       (.await start)
+                       (dotimes [n groups-per-writer]
+                         (let [events (mapv #(es/->event {:type :throughput/event
+                                                          :body {:writer writer :n %}})
+                                            [(* n 2) (inc (* n 2))])
+                               reversed (vec (reverse events))
+                               watermark (get-in (es/tenants store)
+                                                 [tenant-id :tenant/last-event-id])
+                               returned (es/append store {:tenant-id tenant-id
+                                                          :events reversed})]
+                           (swap! observations conj
+                                  {:submitted reversed :watermark watermark
+                                   :returned returned})))))
+                   (range writers))]
+        (.await ready 10 TimeUnit/SECONDS)
+        (.countDown start)
+        (let [completed? (every? #(not= ::timeout (deref % 30000 ::timeout)) tasks)
+              stored (domain-events store tenant-id)
+              stored-by-payload (into {} (map (juxt #(select-keys % [:writer :n]) identity)) stored)
+              returned (mapcat :returned @observations)
+              returned-ids (mapv :event/id returned)]
+          (when-not completed? (run! future-cancel tasks))
+          (is completed? "forced-reassignment writers complete within 30 seconds")
+          (is (= (* writers groups-per-writer 2) (count stored)))
+          (is (= (count returned-ids) (count (set returned-ids))))
+          (is (every? (fn [{:keys [submitted returned watermark]}]
+                        (and (= (mapv #(select-keys % [:writer :n]) submitted)
+                                (mapv #(select-keys % [:writer :n]) returned))
+                             (not= (mapv :event/id submitted) (mapv :event/id returned))
+                             (every? #(or (nil? watermark) (uuid/< watermark %))
+                                     (map :event/id returned))))
+                      @observations))
+          (is (every? (fn [event]
+                        (= (:event/id event)
+                           (:event/id (stored-by-payload (select-keys event [:writer :n])))))
+                      returned)))))))
+
+(deftest hot-versus-distributed-throughput-is-diagnostic
+  (let [run (fn [tenant-count]
+              (with-store
+                #(run-load! % {:writers 8 :appends-per-writer 50
+                               :tenants (vec (repeatedly tenant-count uuid/v4))
+                               :timeout-ms 30000})))
+        hot (run 1)
+        distributed (run 20)]
+    (print-metrics! "SQLite hot comparison" (:elapsed-ns hot) (:latencies-ns hot))
+    (print-metrics! "SQLite distributed comparison" (:elapsed-ns distributed)
+                    (:latencies-ns distributed))
+    (is (:completed? hot))
+    (is (:completed? distributed))
+    (is (= 400 (count (:results hot))))
+    (is (= 400 (count (:results distributed))))))
+
+(deftest ^:extended optional-concurrency-benchmark
+  (if-not (= "true" (System/getenv "GRAIN_PERF_TESTS"))
+    (is true "set GRAIN_PERF_TESTS=true to run the extended benchmark")
+    (doseq [writers [1 5 20 50]]
+      (with-store
+        (fn [store]
+          (run-load! store {:writers writers :appends-per-writer 5
+                            :tenants [(uuid/v4)] :timeout-ms 30000})))
+      (let [trials (repeatedly
+                    3
+                    #(with-store
+                       (fn [store]
+                         (run-load! store {:writers writers :appends-per-writer 20
+                                           :tenants [(uuid/v4)] :timeout-ms 60000}))))
+            trials (vec trials)
+            throughputs (mapv #(/ (count (:results %)) (/ (:elapsed-ns %) 1.0e9)) trials)
+            median (percentile throughputs 0.50)
+            latencies (mapcat :latencies-ns trials)]
+        (println (format "SQLite extended concurrency=%d: median %.1f writes/s"
+                         writers median))
+        (print-metrics! (str "SQLite extended concurrency=" writers)
+                        (reduce + (map :elapsed-ns trials)) latencies)
+        (is (every? :completed? trials))))))

--- a/components/event-store-sqlite-v3/test/ai/obney/grain/event_store_sqlite_v3/append_throughput_test.clj
+++ b/components/event-store-sqlite-v3/test/ai/obney/grain/event_store_sqlite_v3/append_throughput_test.clj
@@ -113,7 +113,7 @@
                                (not (uuid/< watermark initial-watermark)))))
         (is (not (uuid/< watermark (last ids))))))))
 
-(deftest reverse-id-groups-are-reassigned-under-load
+(deftest concurrent-batches-receive-store-assigned-metadata
   (with-store
     (fn [store]
       (let [tenant-id (uuid/v4)
@@ -131,13 +131,12 @@
                          (let [events (mapv #(es/->event {:type :throughput/event
                                                           :body {:writer writer :n %}})
                                             [(* n 2) (inc (* n 2))])
-                               reversed (vec (reverse events))
                                watermark (get-in (es/tenants store)
                                                  [tenant-id :tenant/last-event-id])
                                returned (es/append store {:tenant-id tenant-id
-                                                          :events reversed})]
+                                                          :events events})]
                            (swap! observations conj
-                                  {:submitted reversed :watermark watermark
+                                  {:submitted events :watermark watermark
                                    :returned returned})))))
                    (range writers))]
         (.await ready 10 TimeUnit/SECONDS)
@@ -148,13 +147,15 @@
               returned (mapcat :returned @observations)
               returned-ids (mapv :event/id returned)]
           (when-not completed? (run! future-cancel tasks))
-          (is completed? "forced-reassignment writers complete within 30 seconds")
+          (is completed? "store-assignment writers complete within 30 seconds")
           (is (= (* writers groups-per-writer 2) (count stored)))
           (is (= (count returned-ids) (count (set returned-ids))))
           (is (every? (fn [{:keys [submitted returned watermark]}]
                         (and (= (mapv #(select-keys % [:writer :n]) submitted)
                                 (mapv #(select-keys % [:writer :n]) returned))
                              (not= (mapv :event/id submitted) (mapv :event/id returned))
+                             (every? #(not (contains? % :event/timestamp)) submitted)
+                             (apply = (map :event/timestamp returned))
                              (every? #(or (nil? watermark) (uuid/< watermark %))
                                      (map :event/id returned))))
                       @observations))

--- a/components/event-store-sqlite-v3/test/ai/obney/grain/event_store_sqlite_v3/integration_test.clj
+++ b/components/event-store-sqlite-v3/test/ai/obney/grain/event_store_sqlite_v3/integration_test.clj
@@ -12,7 +12,8 @@
             [clojure.string]
             [clj-uuid :as uuid])
   (:import [java.time OffsetDateTime ZoneOffset Instant]
-           [java.io File]))
+           [java.io File]
+           [java.util UUID]))
 
 ;; -------------------- ;;
 ;; Schema Registration  ;;
@@ -410,6 +411,27 @@
                              (uuid/= a b) 0
                              :else 1))
                      ids)))))
+
+(deftest commit-order-is-established-before-reversing-or-limiting-sqlite
+  (let [tag-id (uuid/v4)
+        low (assoc (es/->event {:type :test/alpha :tags #{[:order tag-id]} :body {:n 1}})
+                   :event/id (UUID/fromString "01900000-0000-7000-8000-000000000001"))
+        high (assoc (es/->event {:type :test/alpha :tags #{[:order tag-id]} :body {:n 2}})
+                    :event/id (UUID/fromString "01900000-0000-7000-8000-000000000002"))]
+    (let [[persisted-high] (es/append *event-store* {:tenant-id *tenant-id* :events [high]})
+          [persisted-low] (es/append *event-store* {:tenant-id *tenant-id* :events [low]})
+          expected [(:event/id persisted-high) (:event/id persisted-low)]
+          ids #(mapv :event/id (read-events %))]
+      (is (= expected (ids {:types #{:test/alpha}})))
+      (is (= expected
+             (ids [{:types #{:test/alpha}}
+                   {:tags #{[:order tag-id]}}])))
+      (is (= (vec (reverse expected))
+             (ids {:types #{:test/alpha} :reverse? true})))
+      (is (= [(:event/id persisted-high)]
+             (ids {:types #{:test/alpha} :limit 1})))
+      (is (= [(:event/id persisted-low)]
+             (ids {:types #{:test/alpha} :reverse? true :limit 1}))))))
 
 (deftest batch-empty-result
   (let [events (non-tx-events

--- a/components/event-store-sqlite-v3/test/ai/obney/grain/event_store_sqlite_v3/integration_test.clj
+++ b/components/event-store-sqlite-v3/test/ai/obney/grain/event_store_sqlite_v3/integration_test.clj
@@ -72,13 +72,11 @@
   ([type tags body]
    (let [event (es/->event (cond-> {:type type :tags tags}
                              body (assoc :body body)))]
-     (es/append *event-store* {:tenant-id *tenant-id* :events [event]})
-     event)))
+     (first (es/append *event-store* {:tenant-id *tenant-id* :events [event]})))))
 
 (defn append-events! [events-data]
   (let [events (mapv es/->event events-data)]
-    (es/append *event-store* {:tenant-id *tenant-id* :events events})
-    events))
+    (es/append *event-store* {:tenant-id *tenant-id* :events events})))
 
 (defn read-events [args]
   (into [] (es/read *event-store* (if (vector? args)
@@ -249,9 +247,9 @@
 
 (deftest events-with-empty-body
   (let [event (es/->event {:type :test/alpha :tags #{}})
-        _ (es/append *event-store* {:tenant-id *tenant-id* :events [event]})
+        [persisted] (es/append *event-store* {:tenant-id *tenant-id* :events [event]})
         read (first (non-tx-events (read-events {})))]
-    (is (= (:event/id event) (:event/id read)))
+    (is (= (:event/id persisted) (:event/id read)))
     (is (= :test/alpha (:event/type read)))))
 
 ;; ============================ ;;
@@ -414,13 +412,11 @@
 
 (deftest commit-order-is-established-before-reversing-or-limiting-sqlite
   (let [tag-id (uuid/v4)
-        low (assoc (es/->event {:type :test/alpha :tags #{[:order tag-id]} :body {:n 1}})
-                   :event/id (UUID/fromString "01900000-0000-7000-8000-000000000001"))
-        high (assoc (es/->event {:type :test/alpha :tags #{[:order tag-id]} :body {:n 2}})
-                    :event/id (UUID/fromString "01900000-0000-7000-8000-000000000002"))]
-    (let [[persisted-high] (es/append *event-store* {:tenant-id *tenant-id* :events [high]})
-          [persisted-low] (es/append *event-store* {:tenant-id *tenant-id* :events [low]})
-          expected [(:event/id persisted-high) (:event/id persisted-low)]
+        first-event (es/->event {:type :test/alpha :tags #{[:order tag-id]} :body {:n 2}})
+        second-event (es/->event {:type :test/alpha :tags #{[:order tag-id]} :body {:n 1}})]
+    (let [[persisted-first] (es/append *event-store* {:tenant-id *tenant-id* :events [first-event]})
+          [persisted-second] (es/append *event-store* {:tenant-id *tenant-id* :events [second-event]})
+          expected [(:event/id persisted-first) (:event/id persisted-second)]
           ids #(mapv :event/id (read-events %))]
       (is (= expected (ids {:types #{:test/alpha}})))
       (is (= expected
@@ -428,9 +424,9 @@
                    {:tags #{[:order tag-id]}}])))
       (is (= (vec (reverse expected))
              (ids {:types #{:test/alpha} :reverse? true})))
-      (is (= [(:event/id persisted-high)]
+      (is (= [(:event/id persisted-first)]
              (ids {:types #{:test/alpha} :limit 1})))
-      (is (= [(:event/id persisted-low)]
+      (is (= [(:event/id persisted-second)]
              (ids {:types #{:test/alpha} :reverse? true :limit 1}))))))
 
 (deftest batch-empty-result
@@ -656,13 +652,19 @@
 
 (deftest timestamp-preserved-as-offsetdatetime
   (let [before (OffsetDateTime/now)
-        _ (append-event! :test/alpha #{} {:n 1})
+        submitted [(es/->event {:type :test/alpha :tags #{} :body {:n 1}})
+                   (es/->event {:type :test/beta :tags #{} :body {:n 2}})]
+        returned (es/append *event-store* {:tenant-id *tenant-id* :events submitted})
         after (OffsetDateTime/now)
-        read (first (non-tx-events (read-events {})))
-        ts (:event/timestamp read)]
+        stored (read-events {})
+        timestamps (mapv :event/timestamp stored)
+        ts (first timestamps)]
     (is (instance? OffsetDateTime ts))
     (is (not (.isBefore ts before)))
-    (is (not (.isAfter ts after)))))
+    (is (not (.isAfter ts after)))
+    (is (apply = timestamps))
+    (is (= (mapv :event/timestamp returned)
+           (mapv :event/timestamp (non-tx-events stored))))))
 
 ;; ======================================== ;;
 ;; J. Tenant Isolation                      ;;

--- a/components/event-store-v2/event-store-v2.allium
+++ b/components/event-store-v2/event-store-v2.allium
@@ -182,8 +182,8 @@ contract EventAppend {
     @invariant SerialisedWrites
         -- Appends are totally serialised against one another, so two concurrent
         -- appends never interleave their events and every appended event lands.
-        -- The order in which events were appended is preserved in the stream's
-        -- total order.
+        -- Serialization governs atomicity and visibility; it does not define
+        -- read order, which is determined solely by event identity.
 
     @invariant TransactionMarker
         -- A plain (unguarded) append also records exactly one transaction-marker
@@ -243,6 +243,8 @@ contract EventRead {
         -- Read results are ordered by event identity, which is the single total
         -- order the store imposes. An empty query reads the whole stream in that
         -- order; any filter reads the matching subset in the same relative order.
+        -- This holds even when storage insertion or append order differs from
+        -- identity order.
 
     @invariant FilteringIsConjunctive
         -- Within one query the filters combine conjunctively: an event is

--- a/components/event-store-v2/src/ai/obney/grain/event_store_v2/core/in_memory.cljc
+++ b/components/event-store-v2/src/ai/obney/grain/event_store_v2/core/in_memory.cljc
@@ -18,6 +18,12 @@
   #?(:clj (dosync (ref-set state nil))
      :cljs (reset! state nil)))
 
+(defn- compare-event-ids [a b]
+  #?(:clj (cond (uuid/< a b) -1
+                (uuid/= a b) 0
+                :else 1)
+     :cljs (compare a b)))
+
 #?(:clj (defn- read-single
           [event-store {:keys [tags types as-of after] :as args}]
           (let [filtered-events (->> (-> event-store :state deref :events)
@@ -32,7 +38,8 @@
                                             as-of (or (uuid/< (:event/id event) as-of)
                                                       (uuid/= (:event/id event) as-of))
                                             after (uuid/> (:event/id event) after)
-                                            :else true)))))]
+                                            :else true))))
+                                      (sort-by :event/id compare-event-ids))]
              (reify
                ;; Support streaming reduction with init value
                clojure.lang.IReduceInit
@@ -67,7 +74,8 @@
                                             as-of (or (< (:event/id event) as-of)
                                                       (= (:event/id event) as-of))
                                             after (> (:event/id event) after)
-                                            :else true)))))]
+                                            :else true))))
+                                      (sort-by :event/id compare-event-ids))]
              (reify
                cljs.core/IReduce
                (-reduce [_ f]
@@ -97,11 +105,7 @@
                                     (update ::events conj event))))
                             {::seen #{} ::events []})
                     ::events
-                    (sort-by :event/id #?(:clj (fn [a b]
-                                                (cond (uuid/< a b) -1
-                                                      (uuid/= a b) 0
-                                                      :else 1))
-                                          :cljs compare)))]
+                    (sort-by :event/id compare-event-ids))]
     #?(:clj (reify
               clojure.lang.IReduceInit
               (reduce [_ f init]

--- a/components/event-store-v2/test/ai/obney/grain/event_store_v2/in_memory_test.clj
+++ b/components/event-store-v2/test/ai/obney/grain/event_store_v2/in_memory_test.clj
@@ -4,7 +4,8 @@
             [ai.obney.grain.schema-util.interface :refer [defschemas]]
             [cognitect.anomalies :as anom]
             [clj-uuid :as uuid])
-  (:import [java.time OffsetDateTime]))
+  (:import [java.time OffsetDateTime]
+           [java.util UUID]))
 
 ;; -------------------- ;;
 ;; Schema Registration  ;;
@@ -322,6 +323,17 @@
                              (uuid/= a b) 0
                              :else 1))
                      ids)))))
+
+(deftest single-read-orders-by-event-id-not-append-position
+  (let [tag-id (uuid/v4)
+        low (assoc (es/->event {:type :test/alpha :tags #{[:order tag-id]} :body {:n 1}})
+                   :event/id (UUID/fromString "01900000-0000-7000-8000-000000000001"))
+        high (assoc (es/->event {:type :test/alpha :tags #{[:order tag-id]} :body {:n 2}})
+                    :event/id (UUID/fromString "01900000-0000-7000-8000-000000000002"))]
+    (es/append *event-store* {:events [high]})
+    (es/append *event-store* {:events [low]})
+    (is (= [(:event/id low) (:event/id high)]
+           (mapv :event/id (read-events {:types #{:test/alpha}}))))))
 
 (deftest batch-empty-result
   (let [events (non-tx-events

--- a/components/event-store-v2/test/ai/obney/grain/event_store_v2/read_batch_test.clj
+++ b/components/event-store-v2/test/ai/obney/grain/event_store_v2/read_batch_test.clj
@@ -2,7 +2,8 @@
   (:require [clojure.test :refer :all]
             [ai.obney.grain.event-store-v2.interface :as es]
             [ai.obney.grain.schema-util.interface :refer [defschemas]]
-            [clj-uuid :as uuid]))
+            [clj-uuid :as uuid])
+  (:import [java.util UUID]))
 
 (defschemas test-event-schemas
   {:test/a [:map]
@@ -114,6 +115,22 @@
                                (uuid/= a b) 0
                                :else 1))
                        ids))))))
+
+(deftest single-and-batch-reads-agree-when-append-order-differs-from-id-order
+  (let [tag-id (uuid/v4)
+        low (assoc (es/->event {:type :test/x :tags #{[:order tag-id]} :body {:n 1}})
+                   :event/id (UUID/fromString "01900000-0000-7000-8000-000000000001"))
+        high (assoc (es/->event {:type :test/x :tags #{[:order tag-id]} :body {:n 2}})
+                    :event/id (UUID/fromString "01900000-0000-7000-8000-000000000002"))]
+    (es/append *event-store* {:events [high]})
+    (es/append *event-store* {:events [low]})
+    (let [single (non-tx-events (read-events {:types #{:test/x}}))
+          batch (non-tx-events
+                 (read-events [{:types #{:test/x}}
+                               {:tags #{[:order tag-id]}}]))
+          expected [(:event/id low) (:event/id high)]]
+      (is (= expected (mapv :event/id single)))
+      (is (= expected (mapv :event/id batch))))))
 
 (deftest per-query-after-filter
   (testing "Each query in a batch applies its own :after filter"

--- a/components/event-store-v3/event-store-v3.allium
+++ b/components/event-store-v3/event-store-v3.allium
@@ -101,11 +101,11 @@ contract EventStream {
         -- name the same tenant.
 
     @invariant AscendingByEventId
-        -- ES4/ES5: results are ordered by event id ascending (oldest first),
-        -- which is also chronological order. A reversed read yields the same
-        -- set in descending id order; a limited read caps the count, taking
-        -- from whichever end the order selects (oldest by default, newest when
-        -- reversed).
+        -- ES4/ES5: results are ordered by event id ascending, independently of
+        -- storage insertion or append order. A reversed read yields the same
+        -- set in descending id order. Ordering happens before limiting, so a
+        -- limited read takes from the selected end (lowest ids by default,
+        -- highest ids when reversed).
 
     @invariant SubsetTagAndTypeMatch
         -- ES5: an event matches a query's tags only if it carries all of them
@@ -419,8 +419,9 @@ surface EventRead {
         -- including across the queries of a batch read.
 
     @guarantee OrderedByEventId
-        -- ES4: events stream in event-id order — chronological, oldest first,
-        -- or newest first when the read is reversed.
+        -- ES4: events stream in event-id order, regardless of append position:
+        -- ascending by default or descending when the read is reversed. A
+        -- limit is applied only after that ordering is established.
 }
 
 -- The administrative boundary: an operator-side caller enumerating every tenant

--- a/components/event-store-v3/event-store-v3.allium
+++ b/components/event-store-v3/event-store-v3.allium
@@ -47,9 +47,9 @@
 -- Value Types
 ------------------------------------------------------------
 
--- A time-ordered event identifier (UUID v7). Identity is global and monotonic:
--- a later-appended event always has a greater id than an earlier one, so the id
--- doubles as the total order over a tenant's stream.
+-- A time-ordered event identifier (UUID v7), minted by the store only after it
+-- has entered the tenant's serialization boundary. A later-appended event has
+-- a greater id than an earlier one, so the id doubles as stream position.
 value EventId {
     -- The embedded creation time that gives the id its ordering. Two ids
     -- compare in the same direction as the times they were minted at.
@@ -176,7 +176,10 @@ entity Event {
     -- The domain meaning of the event (a qualified name such as
     -- :order/placed). Always present; the store does not enumerate the set.
     event_type: String
-    -- When the event was minted.
+    -- The store-controlled recorded-at time of the atomic append. Every domain
+    -- event and transaction marker in one batch shares this timestamp. It is
+    -- canonical UTC at microsecond precision so append results equal rereads
+    -- across backends, including PostgreSQL timestamptz.
     timestamp: Timestamp
     -- The entities this event concerns; reads filter on these.
     tags: Set<EventTag>
@@ -241,13 +244,15 @@ rule AppendBatch {
         -- event shape), or the whole batch is rejected before anything commits.
         -- An unrecognised type or a malformed event fails the batch as a whole.
         events.all(e => has_registered_schema(e.event_type) and conforms_to_schema(e))
+        events.all(e => e.id = null and e.timestamp = null)
 
     ensures:
+        let append_time = now -- canonical UTC, truncated to microseconds
         let marker = Event.created(
             tenant: tenant,
             kind: transaction_marker,
             event_type: tx_marker_type(),
-            timestamp: now,
+            timestamp: append_time,
             tags: {},
             batch_event_ids: event_ids(events),
             metadata: metadata
@@ -257,7 +262,7 @@ rule AppendBatch {
                 tenant: tenant,
                 kind: domain,
                 event_type: e.event_type,
-                timestamp: e.timestamp,
+                timestamp: append_time,
                 tags: e.tags
             )
         -- The durable high-watermark advances to the marker that closed this
@@ -278,7 +283,8 @@ rule AppendBatch {
 -- A conditional (compare-and-swap) append. The caller supplies a predicate and
 -- a filter; the store reads the current events matching that filter for the
 -- tenant, and commits the new events only if the predicate accepts them.
--- Unlike a plain append, a CAS commit records no transaction marker.
+-- A successful CAS append uses the same marker and persistence-envelope rules
+-- as an unconditional append; a rejected CAS mints no ids or timestamps.
 rule CasAppendCommits {
     when: CasAppend(tenant, events, filter, predicate)
     let current = matching_events(tenant, filter)
@@ -286,18 +292,27 @@ rule CasAppendCommits {
         -- Same deny-by-default gate as a plain append: malformed or
         -- unrecognised events fail before the predicate is even consulted.
         events.all(e => has_registered_schema(e.event_type) and conforms_to_schema(e))
+        events.all(e => e.id = null and e.timestamp = null)
         accepts(predicate, current)
     ensures:
+        let append_time = now -- canonical UTC, truncated to microseconds
+        let marker = Event.created(
+            tenant: tenant,
+            kind: transaction_marker,
+            event_type: tx_marker_type(),
+            timestamp: append_time,
+            tags: {},
+            batch_event_ids: event_ids(events)
+        )
         for e in events:
             Event.created(
                 tenant: tenant,
                 kind: domain,
                 event_type: e.event_type,
-                timestamp: e.timestamp,
+                timestamp: append_time,
                 tags: e.tags
             )
-        let last_appended = ordered_last(events)
-        tenant.last_event_id = last_appended.id
+        tenant.last_event_id = marker.id
         if config.publish_on_append:
             for e in events:
                 EventCommitted(tenant: tenant, event: e)
@@ -394,8 +409,9 @@ surface EventAppend {
         -- condition cannot be invalidated between the check and the commit.
 
     @guarantee DenyByDefault
-        -- Events whose type has no registered schema, and malformed arguments,
-        -- are rejected before anything is committed.
+        -- Events whose type has no registered schema, malformed arguments, and
+        -- caller-supplied ids or timestamps are rejected before anything is
+        -- committed.
 }
 
 -- The read boundary: how a caller streams a tenant's events back.

--- a/components/event-store-v3/src/ai/obney/grain/event_store_v3/core.clj
+++ b/components/event-store-v3/src/ai/obney/grain/event_store_v3/core.clj
@@ -4,14 +4,10 @@
             [ai.obney.grain.event-store-v3.interface.protocol :as p :refer [start-event-store]]
             [ai.obney.grain.anomalies.interface :refer [anomaly?]]
             [ai.obney.grain.pubsub.interface :as pubsub]
-            [ai.obney.grain.time.interface :as time]
             [malli.core :as mc]
             [cognitect.anomalies :as anom]
-            [clj-uuid :as uuid]
             [com.brunobonacci.mulog :as u])
-  (:import [clojure.lang ExceptionInfo]
-           [java.time ZoneOffset]
-           [java.time.temporal ChronoUnit]))
+  (:import [clojure.lang ExceptionInfo]))
 
 (defmethod start-event-store :default
   [{{:keys [type]} :conn}]
@@ -92,39 +88,3 @@
      {:event/type type
       :event/tags tags}
      body)))
-
-(defn- next-event-id [previous]
-  (loop [candidate (uuid/v7)]
-    (if (or (nil? previous) (uuid/< previous candidate))
-      candidate
-      (recur (uuid/v7)))))
-
-(defn prepare-append
-  "Assign persistence metadata for one atomic append after serialization and
-   successful CAS evaluation. Domain events and their transaction marker share
-   one store-controlled timestamp."
-  [last-id events tx-metadata]
-  (let [timestamp (-> (time/now)
-                      (.withOffsetSameInstant ZoneOffset/UTC)
-                      (.truncatedTo ChronoUnit/MICROS))
-        domain-events (loop [remaining events previous last-id assigned []]
-                        (if-let [event (first remaining)]
-                          (let [event-id (next-event-id previous)]
-                            (recur (next remaining)
-                                   event-id
-                                   (conj assigned
-                                         (assoc event
-                                                :event/id event-id
-                                                :event/timestamp timestamp))))
-                          assigned))
-        tx-id (next-event-id (or (:event/id (last domain-events)) last-id))
-        tx (assoc (->event
-                   {:type :grain/tx
-                    :body (cond-> {:event-ids (set (mapv :event/id domain-events))}
-                            tx-metadata (assoc :metadata tx-metadata))})
-                  :event/id tx-id
-                  :event/timestamp timestamp)]
-    {:events domain-events
-     :events-with-tx (conj domain-events tx)
-     :last-event-id tx-id
-     :timestamp timestamp}))

--- a/components/event-store-v3/src/ai/obney/grain/event_store_v3/core.clj
+++ b/components/event-store-v3/src/ai/obney/grain/event_store_v3/core.clj
@@ -61,9 +61,12 @@
       (let [result (p/append event-store args)]
         (if (anomaly? result)
           result
-          (let [{:keys [tenant-id]} args]
+          (let [{:keys [tenant-id]} args
+                persisted-events (if (sequential? result) result events)]
             (when event-pubsub
-              (run! #(pubsub/pub event-pubsub {:message (assoc % :grain/tenant-id tenant-id)}) events))))))))
+              (run! #(pubsub/pub event-pubsub {:message (assoc % :grain/tenant-id tenant-id)})
+                    persisted-events))
+            result))))))
 
 (defn tenants
   [event-store]

--- a/components/event-store-v3/src/ai/obney/grain/event_store_v3/core.clj
+++ b/components/event-store-v3/src/ai/obney/grain/event_store_v3/core.clj
@@ -9,7 +9,9 @@
             [cognitect.anomalies :as anom]
             [clj-uuid :as uuid]
             [com.brunobonacci.mulog :as u])
-  (:import [clojure.lang ExceptionInfo]))
+  (:import [clojure.lang ExceptionInfo]
+           [java.time ZoneOffset]
+           [java.time.temporal ChronoUnit]))
 
 (defmethod start-event-store :default
   [{{:keys [type]} :conn}]
@@ -40,7 +42,7 @@
 
          ;; Schema validation issues
          (try (->> events
-                   (mapv #(mc/explain [:and ::schemas/event (:event/type %)] %))
+                   (mapv #(mc/explain [:and ::schemas/appendable-event (:event/type %)] %))
                    (filterv (complement nil?)))
               (catch ExceptionInfo _
                 {::anom/category ::anom/fault
@@ -87,8 +89,42 @@
      ::anom/message "Invalid arguments"
      :explain/data validation-error}
     (merge
-     {:event/id (uuid/v7)
-      :event/timestamp (time/now)
-      :event/type type
+     {:event/type type
       :event/tags tags}
      body)))
+
+(defn- next-event-id [previous]
+  (loop [candidate (uuid/v7)]
+    (if (or (nil? previous) (uuid/< previous candidate))
+      candidate
+      (recur (uuid/v7)))))
+
+(defn prepare-append
+  "Assign persistence metadata for one atomic append after serialization and
+   successful CAS evaluation. Domain events and their transaction marker share
+   one store-controlled timestamp."
+  [last-id events tx-metadata]
+  (let [timestamp (-> (time/now)
+                      (.withOffsetSameInstant ZoneOffset/UTC)
+                      (.truncatedTo ChronoUnit/MICROS))
+        domain-events (loop [remaining events previous last-id assigned []]
+                        (if-let [event (first remaining)]
+                          (let [event-id (next-event-id previous)]
+                            (recur (next remaining)
+                                   event-id
+                                   (conj assigned
+                                         (assoc event
+                                                :event/id event-id
+                                                :event/timestamp timestamp))))
+                          assigned))
+        tx-id (next-event-id (or (:event/id (last domain-events)) last-id))
+        tx (assoc (->event
+                   {:type :grain/tx
+                    :body (cond-> {:event-ids (set (mapv :event/id domain-events))}
+                            tx-metadata (assoc :metadata tx-metadata))})
+                  :event/id tx-id
+                  :event/timestamp timestamp)]
+    {:events domain-events
+     :events-with-tx (conj domain-events tx)
+     :last-event-id tx-id
+     :timestamp timestamp}))

--- a/components/event-store-v3/src/ai/obney/grain/event_store_v3/core/in_memory.clj
+++ b/components/event-store-v3/src/ai/obney/grain/event_store_v3/core/in_memory.clj
@@ -1,7 +1,7 @@
 (ns ai.obney.grain.event-store-v3.core.in-memory
   (:refer-clojure :exclude [read])
   (:require [ai.obney.grain.event-store-v3.interface.protocol :as p]
-            [ai.obney.grain.event-store-v3.core :refer [->event]]
+            [ai.obney.grain.event-store-v3.core :refer [prepare-append]]
             [cognitect.anomalies :as anom]
             [clojure.set :as set]
             [com.brunobonacci.mulog :as u]
@@ -104,31 +104,6 @@
 (defn- tag-events-with-tenant [tenant-id events]
   (mapv #(assoc % :grain/tenant-id tenant-id) events))
 
-(defn- strictly-increasing-after?
-  [last-id events]
-  (reduce (fn [previous event]
-            (let [event-id (:event/id event)]
-              (if (and event-id
-                       (or (nil? previous) (uuid/< previous event-id)))
-                event-id
-                (reduced false))))
-          last-id
-          events))
-
-(defn- assign-commit-ordered-ids
-  [last-id events]
-  (if (strictly-increasing-after? last-id events)
-    events
-    (loop [remaining events previous last-id assigned []]
-      (if-let [event (first remaining)]
-        (let [event-id (loop [candidate (uuid/v7)]
-                         (if (or (nil? previous) (uuid/< previous candidate))
-                           candidate
-                           (recur (uuid/v7))))]
-          (recur (next remaining) event-id
-                 (conj assigned (assoc event :event/id event-id))))
-        assigned))))
-
 (defn append
   [event-store {{:keys [predicate-fn] :as cas} :cas
                 :keys [tenant-id events tx-metadata]}]
@@ -139,38 +114,28 @@
    (dosync
     (let [last-id (get-in @(:state event-store)
                           [:tenants tenant-id :tenant/last-event-id])
-          events (assign-commit-ordered-ids last-id events)
-          tx (first (assign-commit-ordered-ids
-                     (:event/id (last events))
-                     [(->event
-                       {:type :grain/tx
-                        :body {:event-ids (set (mapv :event/id events))
-                               :metadata tx-metadata}})]))]
+          persist! (fn []
+                     (let [{:keys [events events-with-tx last-event-id]}
+                           (prepare-append last-id events tx-metadata)]
+                       (alter (:state event-store)
+                              (fn [s]
+                                (-> s
+                                    (update :events into
+                                            (tag-events-with-tenant tenant-id events-with-tx))
+                                    (assoc-in [:tenants tenant-id :tenant/last-event-id]
+                                              last-event-id))))
+                       events))]
       (if cas
         (let [events* (read event-store (assoc cas :tenant-id tenant-id))
               pred-result (predicate-fn events*)]
           (if pred-result
-            (do
-              (alter (:state event-store)
-                     (fn [s]
-                       (-> s
-                           (update :events into (tag-events-with-tenant tenant-id events))
-                           (assoc-in [:tenants tenant-id :tenant/last-event-id]
-                                     (:event/id (last events))))))
-              events)
+            (persist!)
             (let [anomaly {::anom/category ::anom/conflict
                            ::anom/message "CAS failed"
                            :cas cas}]
               (u/log :grain/cas-failed :anomaly anomaly)
               anomaly)))
-        (do
-          (alter (:state event-store)
-                 (fn [s]
-                   (-> s
-                       (update :events into (tag-events-with-tenant tenant-id (conj events tx)))
-                       (assoc-in [:tenants tenant-id :tenant/last-event-id]
-                                 (:event/id tx)))))
-          events))))))
+        (persist!))))))
 
 (defn tenants
   [event-store]

--- a/components/event-store-v3/src/ai/obney/grain/event_store_v3/core/in_memory.clj
+++ b/components/event-store-v3/src/ai/obney/grain/event_store_v3/core/in_memory.clj
@@ -1,7 +1,7 @@
 (ns ai.obney.grain.event-store-v3.core.in-memory
   (:refer-clojure :exclude [read])
   (:require [ai.obney.grain.event-store-v3.interface.protocol :as p]
-            [ai.obney.grain.event-store-v3.core :refer [prepare-append]]
+            [ai.obney.grain.event-store-v3.interface.backend :refer [prepare-append]]
             [cognitect.anomalies :as anom]
             [clojure.set :as set]
             [com.brunobonacci.mulog :as u]

--- a/components/event-store-v3/src/ai/obney/grain/event_store_v3/core/in_memory.clj
+++ b/components/event-store-v3/src/ai/obney/grain/event_store_v3/core/in_memory.clj
@@ -21,6 +21,11 @@
 (defn- strip-tenant-id [event]
   (dissoc event :grain/tenant-id))
 
+(defn- compare-event-ids [a b]
+  (cond (uuid/< a b) -1
+        (uuid/= a b) 0
+        :else 1))
+
 (defn- read-single
   [event-store {:keys [tenant-id tags types as-of after reverse? limit] :as args}]
   (let [filtered-events (cond->> (->> (-> event-store :state deref :events)
@@ -37,7 +42,8 @@
                                                       (uuid/= (:event/id event) as-of))
                                             after (uuid/> (:event/id event) after)
                                             :else true))))
-                                      (map strip-tenant-id))
+                                      (map strip-tenant-id)
+                                      (sort-by :event/id compare-event-ids))
                           reverse? reverse
                           limit    (take limit))]
      (reify
@@ -70,10 +76,7 @@
                                     (update ::events conj event))))
                             {::seen #{} ::events []})
                     ::events
-                    (sort-by :event/id (fn [a b]
-                                         (cond (uuid/< a b) -1
-                                               (uuid/= a b) 0
-                                               :else 1))))]
+                    (sort-by :event/id compare-event-ids))]
     (reify
       clojure.lang.IReduceInit
       (reduce [_ f init]
@@ -101,6 +104,31 @@
 (defn- tag-events-with-tenant [tenant-id events]
   (mapv #(assoc % :grain/tenant-id tenant-id) events))
 
+(defn- strictly-increasing-after?
+  [last-id events]
+  (reduce (fn [previous event]
+            (let [event-id (:event/id event)]
+              (if (and event-id
+                       (or (nil? previous) (uuid/< previous event-id)))
+                event-id
+                (reduced false))))
+          last-id
+          events))
+
+(defn- assign-commit-ordered-ids
+  [last-id events]
+  (if (strictly-increasing-after? last-id events)
+    events
+    (loop [remaining events previous last-id assigned []]
+      (if-let [event (first remaining)]
+        (let [event-id (loop [candidate (uuid/v7)]
+                         (if (or (nil? previous) (uuid/< previous candidate))
+                           candidate
+                           (recur (uuid/v7))))]
+          (recur (next remaining) event-id
+                 (conj assigned (assoc event :event/id event-id))))
+        assigned))))
+
 (defn append
   [event-store {{:keys [predicate-fn] :as cas} :cas
                 :keys [tenant-id events tx-metadata]}]
@@ -108,32 +136,41 @@
    ::append
    [:grain/event-ids (map :event/id events)
     :metric/name "GrainAppendEvents"]
-   (let [tx (->event
-             {:type :grain/tx
-              :body {:event-ids (set (mapv :event/id events))
-                     :metadata tx-metadata}})]
-     (dosync
+   (dosync
+    (let [last-id (get-in @(:state event-store)
+                          [:tenants tenant-id :tenant/last-event-id])
+          events (assign-commit-ordered-ids last-id events)
+          tx (first (assign-commit-ordered-ids
+                     (:event/id (last events))
+                     [(->event
+                       {:type :grain/tx
+                        :body {:event-ids (set (mapv :event/id events))
+                               :metadata tx-metadata}})]))]
       (if cas
         (let [events* (read event-store (assoc cas :tenant-id tenant-id))
               pred-result (predicate-fn events*)]
           (if pred-result
-            (alter (:state event-store)
-                   (fn [s]
-                     (-> s
-                         (update :events into (tag-events-with-tenant tenant-id events))
-                         (assoc-in [:tenants tenant-id :tenant/last-event-id]
-                                   (:event/id (last events))))))
+            (do
+              (alter (:state event-store)
+                     (fn [s]
+                       (-> s
+                           (update :events into (tag-events-with-tenant tenant-id events))
+                           (assoc-in [:tenants tenant-id :tenant/last-event-id]
+                                     (:event/id (last events))))))
+              events)
             (let [anomaly {::anom/category ::anom/conflict
                            ::anom/message "CAS failed"
                            :cas cas}]
               (u/log :grain/cas-failed :anomaly anomaly)
               anomaly)))
-        (alter (:state event-store)
-               (fn [s]
-                 (-> s
-                     (update :events into (tag-events-with-tenant tenant-id (conj events tx)))
-                     (assoc-in [:tenants tenant-id :tenant/last-event-id]
-                               (:event/id tx))))))))))
+        (do
+          (alter (:state event-store)
+                 (fn [s]
+                   (-> s
+                       (update :events into (tag-events-with-tenant tenant-id (conj events tx)))
+                       (assoc-in [:tenants tenant-id :tenant/last-event-id]
+                                 (:event/id tx)))))
+          events))))))
 
 (defn tenants
   [event-store]

--- a/components/event-store-v3/src/ai/obney/grain/event_store_v3/interface.clj
+++ b/components/event-store-v3/src/ai/obney/grain/event_store_v3/interface.clj
@@ -8,10 +8,6 @@
   [{:keys [_type _body _tags] :as args}]
   (core/->event args))
 
-(defn prepare-append
-  [last-id events tx-metadata]
-  (core/prepare-append last-id events tx-metadata))
-
 (defn start
   [config]
   (core/start config))

--- a/components/event-store-v3/src/ai/obney/grain/event_store_v3/interface.clj
+++ b/components/event-store-v3/src/ai/obney/grain/event_store_v3/interface.clj
@@ -8,6 +8,10 @@
   [{:keys [_type _body _tags] :as args}]
   (core/->event args))
 
+(defn prepare-append
+  [last-id events tx-metadata]
+  (core/prepare-append last-id events tx-metadata))
+
 (defn start
   [config]
   (core/start config))

--- a/components/event-store-v3/src/ai/obney/grain/event_store_v3/interface/backend.clj
+++ b/components/event-store-v3/src/ai/obney/grain/event_store_v3/interface/backend.clj
@@ -1,0 +1,41 @@
+(ns ai.obney.grain.event-store-v3.interface.backend
+  "Shared persistence-envelope preparation for event-store backends."
+  (:require [ai.obney.grain.time.interface :as time]
+            [clj-uuid :as uuid])
+  (:import [java.time ZoneOffset]
+           [java.time.temporal ChronoUnit]))
+
+(defn- next-event-id [previous]
+  (loop [candidate (uuid/v7)]
+    (if (or (nil? previous) (uuid/< previous candidate))
+      candidate
+      (recur (uuid/v7)))))
+
+(defn prepare-append
+  "Assign final persistence metadata and create the transaction marker for one
+   atomic append. Intended only for event-store backend implementations."
+  [last-id events tx-metadata]
+  (let [timestamp (-> (time/now)
+                      (.withOffsetSameInstant ZoneOffset/UTC)
+                      (.truncatedTo ChronoUnit/MICROS))
+        domain-events (loop [remaining events previous last-id assigned []]
+                        (if-let [event (first remaining)]
+                          (let [event-id (next-event-id previous)]
+                            (recur (next remaining)
+                                   event-id
+                                   (conj assigned
+                                         (assoc event
+                                                :event/id event-id
+                                                :event/timestamp timestamp))))
+                          assigned))
+        tx-id (next-event-id (or (:event/id (last domain-events)) last-id))
+        tx (cond-> {:event/id tx-id
+                    :event/timestamp timestamp
+                    :event/type :grain/tx
+                    :event/tags #{}
+                    :event-ids (set (mapv :event/id domain-events))}
+             tx-metadata (assoc :metadata tx-metadata))]
+    {:events domain-events
+     :events-with-tx (conj domain-events tx)
+     :last-event-id tx-id
+     :timestamp timestamp}))

--- a/components/event-store-v3/src/ai/obney/grain/event_store_v3/interface/protocol.clj
+++ b/components/event-store-v3/src/ai/obney/grain/event_store_v3/interface/protocol.clj
@@ -18,6 +18,13 @@
 
      :events - A vector of events to append to the event store.
 
+       The store establishes final event IDs at its tenant serialization
+       boundary. Caller-supplied IDs are retained when already strictly after
+       the committed tenant watermark; otherwise the batch is re-IDed.
+
+       On success, returns the persisted domain events, including their final
+       IDs. Callers that retain an event ID must use this returned value.
+
      :tx-metadata - An optional map of metadata to associate with the transaction.
 
      :cas - An optional map with the following keys:

--- a/components/event-store-v3/src/ai/obney/grain/event_store_v3/interface/protocol.clj
+++ b/components/event-store-v3/src/ai/obney/grain/event_store_v3/interface/protocol.clj
@@ -18,12 +18,16 @@
 
      :events - A vector of events to append to the event store.
 
-       The store establishes final event IDs at its tenant serialization
-       boundary. Caller-supplied IDs are retained when already strictly after
-       the committed tenant watermark; otherwise the batch is re-IDed.
+       Events supplied to append must not contain :event/id or
+       :event/timestamp. The store assigns both fields after tenant
+       serialization and successful CAS evaluation. Every event and the
+       transaction marker in one append share a single recorded-at timestamp;
+       the timestamp is canonical UTC at portable microsecond precision. IDs
+       are UUIDv7 values strictly ordered after the committed watermark.
 
        On success, returns the persisted domain events, including their final
-       IDs. Callers that retain an event ID must use this returned value.
+       IDs and timestamps. Callers that retain persistence metadata must use
+       this returned value.
 
      :tx-metadata - An optional map of metadata to associate with the transaction.
 

--- a/components/event-store-v3/src/ai/obney/grain/event_store_v3/interface/schemas.clj
+++ b/components/event-store-v3/src/ai/obney/grain/event_store_v3/interface/schemas.clj
@@ -6,6 +6,14 @@
 
 (defn- uuid-v7? [x] (and (uuid? x) (= 7 (uuid/get-version x))))
 
+(defn- no-persistence-metadata? [event]
+  (not (or (contains? event :event/id)
+           (contains? event :event/timestamp))))
+
+(defn- body-has-no-persistence-metadata? [{:keys [body]}]
+  (not (or (contains? body :event/id)
+           (contains? body :event/timestamp))))
+
 (defn- same-tenant-id?
   "Validates that all queries in a batch have the same :tenant-id."
   [queries]
@@ -30,6 +38,14 @@
             [:event/timestamp ::timestamp]
             [:event/tags ::tags]
             [:event/type ::type]]
+
+   ::appendable-event
+   [:and
+    [:fn {:error/message "Event IDs and timestamps are assigned by append"}
+     no-persistence-metadata?]
+    [:map
+     [:event/tags ::tags]
+     [:event/type ::type]]]
 
    ::as-of-or-after
    [:fn {:error/message "Cannot supply both :as-of and :after"} as-of-or-after]
@@ -70,15 +86,18 @@
    ::append-args
    [:map
     [:tenant-id ::tenant-id]
-    [:events [:vector ::event]]
+    [:events [:vector ::appendable-event]]
     [:tx-metadata {:optional true} [:map]]
     [:cas {:optional true} ::cas]]
 
    ::->event-args
-   [:map
-    [:type ::type]
-    [:tags {:optional true} ::tags]
-    [:body {:optional true} [:map]]]
+   [:and
+    [:fn {:error/message "Event body cannot supply persistence metadata"}
+     body-has-no-persistence-metadata?]
+    [:map
+     [:type ::type]
+     [:tags {:optional true} ::tags]
+     [:body {:optional true} [:map]]]]
 
    :grain/tx
    [:map

--- a/components/event-store-v3/test/ai/obney/grain/event_store_v3/in_memory_test.clj
+++ b/components/event-store-v3/test/ai/obney/grain/event_store_v3/in_memory_test.clj
@@ -6,7 +6,7 @@
             [cognitect.anomalies :as anom]
             [clojure.core.async :as async]
             [clj-uuid :as uuid])
-  (:import [java.time OffsetDateTime]
+  (:import [java.time OffsetDateTime ZoneOffset]
            [java.util UUID]))
 
 ;; -------------------- ;;
@@ -50,13 +50,11 @@
   ([type tags body]
    (let [event (es/->event (cond-> {:type type :tags tags}
                              body (assoc :body body)))]
-     (es/append *event-store* {:tenant-id *tenant-id* :events [event]})
-     event)))
+     (first (es/append *event-store* {:tenant-id *tenant-id* :events [event]})))))
 
 (defn append-events! [events-data]
   (let [events (mapv es/->event events-data)]
-    (es/append *event-store* {:tenant-id *tenant-id* :events events})
-    events))
+    (es/append *event-store* {:tenant-id *tenant-id* :events events})))
 
 (defn read-events [args]
   (into [] (es/read *event-store* (if (vector? args)
@@ -90,6 +88,20 @@
         (is (pos? (count events))))
       (finally
         (es/stop store)))))
+
+(deftest event-construction-does-not-assign-persistence-metadata
+  (let [event (es/->event {:type :test/alpha :tags #{} :body {:val 1}})]
+    (is (not (contains? event :event/id)))
+    (is (not (contains? event :event/timestamp)))))
+
+(deftest append-rejects-caller-supplied-persistence-metadata
+  (doseq [metadata [{:event/id (uuid/v7)}
+                    {:event/timestamp (OffsetDateTime/now)}]]
+    (let [event (merge (es/->event {:type :test/alpha :tags #{} :body {:val 1}})
+                       metadata)
+          result (es/append *event-store* {:tenant-id *tenant-id* :events [event]})]
+      (is (= ::anom/incorrect (::anom/category result)))))
+  (is (empty? (read-events {}))))
 
 ;; ================================ ;;
 ;; B. Basic Append & Read (8 tests) ;;
@@ -168,9 +180,9 @@
 
 (deftest events-with-empty-body
   (let [event (es/->event {:type :test/alpha :tags #{}})
-        _ (es/append *event-store* {:tenant-id *tenant-id* :events [event]})
+        [persisted] (es/append *event-store* {:tenant-id *tenant-id* :events [event]})
         read (first (non-tx-events (read-events {})))]
-    (is (= (:event/id event) (:event/id read)))
+    (is (= (:event/id persisted) (:event/id read)))
     (is (= :test/alpha (:event/type read)))))
 
 ;; ============================ ;;
@@ -333,13 +345,11 @@
 
 (deftest commit-order-is-established-before-reversing-or-limiting
   (let [tag-id (uuid/v4)
-        low (assoc (es/->event {:type :test/alpha :tags #{[:order tag-id]} :body {:n 1}})
-                   :event/id (UUID/fromString "01900000-0000-7000-8000-000000000001"))
-        high (assoc (es/->event {:type :test/alpha :tags #{[:order tag-id]} :body {:n 2}})
-                    :event/id (UUID/fromString "01900000-0000-7000-8000-000000000002"))]
-    (let [[persisted-high] (es/append *event-store* {:tenant-id *tenant-id* :events [high]})
-          [persisted-low] (es/append *event-store* {:tenant-id *tenant-id* :events [low]})
-          expected [(:event/id persisted-high) (:event/id persisted-low)]
+        first-event (es/->event {:type :test/alpha :tags #{[:order tag-id]} :body {:n 2}})
+        second-event (es/->event {:type :test/alpha :tags #{[:order tag-id]} :body {:n 1}})]
+    (let [[persisted-first] (es/append *event-store* {:tenant-id *tenant-id* :events [first-event]})
+          [persisted-second] (es/append *event-store* {:tenant-id *tenant-id* :events [second-event]})
+          expected [(:event/id persisted-first) (:event/id persisted-second)]
           ids #(mapv :event/id (read-events %))]
       (is (= expected (ids {:types #{:test/alpha}})))
       (is (= expected
@@ -347,9 +357,9 @@
                    {:tags #{[:order tag-id]}}])))
       (is (= (vec (reverse expected))
              (ids {:types #{:test/alpha} :reverse? true})))
-      (is (= [(:event/id persisted-high)]
+      (is (= [(:event/id persisted-first)]
              (ids {:types #{:test/alpha} :limit 1})))
-      (is (= [(:event/id persisted-low)]
+      (is (= [(:event/id persisted-second)]
              (ids {:types #{:test/alpha} :reverse? true :limit 1}))))))
 
 (deftest batch-empty-result
@@ -422,7 +432,7 @@
                         :predicate-fn (constantly true)}})]
     (is (not (::anom/category result)))
     (is (= 1 (count (non-tx-events (read-events {:types #{:test/alpha}})))))
-    (is (empty? (tx-events (read-events {}))))))
+    (is (= 1 (count (tx-events (read-events {})))))))
 
 (deftest cas-predicate-false-returns-conflict-anomaly
   (let [event (es/->event {:type :test/alpha :tags #{} :body {:n 1}})
@@ -627,13 +637,22 @@
 
 (deftest timestamp-preserved-as-offsetdatetime
   (let [before (OffsetDateTime/now)
-        _ (append-event! :test/alpha #{} {:n 1})
+        submitted [(es/->event {:type :test/alpha :tags #{} :body {:n 1}})
+                   (es/->event {:type :test/beta :tags #{} :body {:n 2}})]
+        returned (es/append *event-store* {:tenant-id *tenant-id* :events submitted})
         after (OffsetDateTime/now)
-        read (first (non-tx-events (read-events {})))
-        ts (:event/timestamp read)]
+        stored (read-events {})
+        timestamps (mapv :event/timestamp stored)
+        ts (first timestamps)]
     (is (instance? OffsetDateTime ts))
     (is (not (.isBefore ts before)))
-    (is (not (.isAfter ts after)))))
+    (is (not (.isAfter ts after)))
+    (is (= ZoneOffset/UTC (.getOffset ts)) "store timestamps are canonical UTC")
+    (is (zero? (mod (.getNano ts) 1000))
+        "store timestamps use portable microsecond precision")
+    (is (apply = timestamps) "domain events and transaction marker share one timestamp")
+    (is (= (mapv :event/timestamp returned)
+           (mapv :event/timestamp (non-tx-events stored))))))
 
 ;; ======================================== ;;
 ;; J. Tenant Isolation (4 tests)            ;;

--- a/components/event-store-v3/test/ai/obney/grain/event_store_v3/in_memory_test.clj
+++ b/components/event-store-v3/test/ai/obney/grain/event_store_v3/in_memory_test.clj
@@ -6,7 +6,8 @@
             [cognitect.anomalies :as anom]
             [clojure.core.async :as async]
             [clj-uuid :as uuid])
-  (:import [java.time OffsetDateTime]))
+  (:import [java.time OffsetDateTime]
+           [java.util UUID]))
 
 ;; -------------------- ;;
 ;; Schema Registration  ;;
@@ -329,6 +330,27 @@
                              (uuid/= a b) 0
                              :else 1))
                      ids)))))
+
+(deftest commit-order-is-established-before-reversing-or-limiting
+  (let [tag-id (uuid/v4)
+        low (assoc (es/->event {:type :test/alpha :tags #{[:order tag-id]} :body {:n 1}})
+                   :event/id (UUID/fromString "01900000-0000-7000-8000-000000000001"))
+        high (assoc (es/->event {:type :test/alpha :tags #{[:order tag-id]} :body {:n 2}})
+                    :event/id (UUID/fromString "01900000-0000-7000-8000-000000000002"))]
+    (let [[persisted-high] (es/append *event-store* {:tenant-id *tenant-id* :events [high]})
+          [persisted-low] (es/append *event-store* {:tenant-id *tenant-id* :events [low]})
+          expected [(:event/id persisted-high) (:event/id persisted-low)]
+          ids #(mapv :event/id (read-events %))]
+      (is (= expected (ids {:types #{:test/alpha}})))
+      (is (= expected
+             (ids [{:types #{:test/alpha}}
+                   {:tags #{[:order tag-id]}}])))
+      (is (= (vec (reverse expected))
+             (ids {:types #{:test/alpha} :reverse? true})))
+      (is (= [(:event/id persisted-high)]
+             (ids {:types #{:test/alpha} :limit 1})))
+      (is (= [(:event/id persisted-low)]
+             (ids {:types #{:test/alpha} :reverse? true :limit 1}))))))
 
 (deftest batch-empty-result
   (let [events (non-tx-events

--- a/components/todo-processor-v2/test/ai/obney/grain/todo_processor_v2/dynamic_tenant_replay_test.clj
+++ b/components/todo-processor-v2/test/ai/obney/grain/todo_processor_v2/dynamic_tenant_replay_test.clj
@@ -48,14 +48,16 @@
                                            {})
                             :topics #{:test/dynamic-replay-trigger}}})
 
-        (let [evts (mapv (fn [i]
-                           (->event {:type :test/dynamic-replay-trigger
-                                     :tags #{}
-                                     :body {:n i}}))
-                         (range 3))
+        (let [evts (es/append
+                    event-store
+                    {:tenant-id tid
+                     :events (mapv (fn [i]
+                                     (->event {:type :test/dynamic-replay-trigger
+                                               :tags #{}
+                                               :body {:n i}}))
+                                   (range 3))})
               cp (make-checkpoint-event proc-name
                                         (:event/id (last evts)))]
-          (es/append event-store {:tenant-id tid :events evts})
           (es/append event-store {:tenant-id tid :events [cp]}))
 
         (let [ts-atom (atom #{})

--- a/components/todo-processor-v2/test/ai/obney/grain/todo_processor_v2/interface_test.clj
+++ b/components/todo-processor-v2/test/ai/obney/grain/todo_processor_v2/interface_test.clj
@@ -8,7 +8,8 @@
             [ai.obney.grain.periodic-task.interface :as pt]
             [ai.obney.grain.periodic-task.core :as pt-core]
             [cognitect.anomalies :as anom]
-            [clj-uuid :as uuid]))
+            [clj-uuid :as uuid])
+  (:import [java.time OffsetDateTime]))
 
 (def test-tenant-id (random-uuid))
 
@@ -56,7 +57,9 @@
   [event handler-fn]
   {:event (if (:event/id event)
             event
-            (-> (es/prepare-append nil [event] nil) :events first))
+            (assoc event
+                   :event/id (uuid/v7)
+                   :event/timestamp (OffsetDateTime/now)))
    :handler-fn handler-fn
    :event-store *event-store*
    :tenant-id test-tenant-id})

--- a/components/todo-processor-v2/test/ai/obney/grain/todo_processor_v2/interface_test.clj
+++ b/components/todo-processor-v2/test/ai/obney/grain/todo_processor_v2/interface_test.clj
@@ -54,7 +54,9 @@
 
 (defn make-context
   [event handler-fn]
-  {:event event
+  {:event (if (:event/id event)
+            event
+            (-> (es/prepare-append nil [event] nil) :events first))
    :handler-fn handler-fn
    :event-store *event-store*
    :tenant-id test-tenant-id})
@@ -714,14 +716,16 @@
   (testing "Overlapping pure batches conflict when a later checkpoint already exists"
     (let [tenant-id (random-uuid)
           processor-name :test/overlapping-batch-proc
-          source-events (mapv #(make-event :test/event-1 :body {:num %}) (range 20))
+          source-events (es/append *event-store*
+                                  {:tenant-id tenant-id
+                                   :events (mapv #(make-event :test/event-1 :body {:num %})
+                                                 (range 20))})
           result-events (fn [events]
                           (mapv (fn [event]
                                   (es/->event
                                    {:type :test/batch-result
                                     :body {:source-event-id (:event/id event)}}))
                                 events))]
-      (es/append *event-store* {:tenant-id tenant-id :events source-events})
       (let [full-batch source-events
             overlapping-batch (subvec source-events 0 10)
             full-result (#'core/append-batch-with-checkpoint
@@ -750,14 +754,16 @@
   (testing "Non-overlapping pure batches can commit sequentially"
     (let [tenant-id (random-uuid)
           processor-name :test/adjacent-batch-proc
-          source-events (mapv #(make-event :test/event-1 :body {:num %}) (range 20))
+          source-events (es/append *event-store*
+                                  {:tenant-id tenant-id
+                                   :events (mapv #(make-event :test/event-1 :body {:num %})
+                                                 (range 20))})
           result-events (fn [events]
                           (mapv (fn [event]
                                   (es/->event
                                    {:type :test/batch-result
                                     :body {:source-event-id (:event/id event)}}))
                                 events))]
-      (es/append *event-store* {:tenant-id tenant-id :events source-events})
       (let [batch-1 (subvec source-events 0 10)
             batch-2 (subvec source-events 10 20)
             result-1 (#'core/append-batch-with-checkpoint
@@ -786,7 +792,10 @@
   (testing "Old checkpoint shape still blocks stale overlapping batch commits"
     (let [tenant-id (random-uuid)
           processor-name :test/legacy-overlap-batch-proc
-          source-events (mapv #(make-event :test/event-1 :body {:num %}) (range 20))
+          source-events (es/append *event-store*
+                                  {:tenant-id tenant-id
+                                   :events (mapv #(make-event :test/event-1 :body {:num %})
+                                                 (range 20))})
           result-events (fn [events]
                           (mapv (fn [event]
                                   (es/->event
@@ -819,8 +828,10 @@
                     (swap! processed conj (:event/id event))
                     {})
           tenant-id (random-uuid)
-          events (mapv (fn [_] (make-event :test/event-1 :body {:num 1})) (range 50))]
-      (es/append *event-store* {:tenant-id tenant-id :events events})
+          events (es/append *event-store*
+                           {:tenant-id tenant-id
+                            :events (mapv (fn [_] (make-event :test/event-1 :body {:num 1}))
+                                          (range 50))})]
       (let [processor (core/start-polling
                         {:event-store *event-store*
                          :tenant-id tenant-id
@@ -1084,8 +1095,10 @@
 (deftest pt-cas2-processor-handles-trigger-exactly-once
   (testing "PT-CAS2: Two processors process same trigger — only one checkpoints"
     (let [tenant-id (random-uuid)
-          trigger (es/->event {:type :test/billing-trigger
-                               :body {:period "2026-03-23"}})
+          [trigger] (es/append *event-store*
+                              {:tenant-id tenant-id
+                               :events [(es/->event {:type :test/billing-trigger
+                                                    :body {:period "2026-03-23"}})]})
           billed (atom 0)
           handler (fn [{:keys [event]}]
                     (swap! billed inc)
@@ -1093,8 +1106,6 @@
                      [(es/->event {:type :test/billing-done
                                    :body {:period (:period event)
                                           :billed-by (random-uuid)}})]})]
-      ;; Append the trigger
-      (es/append *event-store* {:tenant-id tenant-id :events [trigger]})
       ;; Two "processors" try to handle it
       (core/process-event {:event trigger :handler-fn handler :event-store *event-store*
                            :tenant-id tenant-id :processor-name :test/billing-proc})

--- a/docs/code-agent-tools.md
+++ b/docs/code-agent-tools.md
@@ -15,7 +15,7 @@ Add the package to the application project:
 ```clojure
 obneyai/grain-code-agent-tools
 {:git/url "https://github.com/ObneyAI/grain.git"
- :git/sha "6817ba3ab82b7fc916150ab4c783d5a1b36d2919"
+ :git/sha "1616dacab3e287fbabd6a5ca9fe3d0ee51326cf4"
  :deps/root "projects/grain-code-agent-tools"}
 ```
 

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -7,7 +7,7 @@ Multi-tenant CQRS/Event Sourcing with an in-memory event store. Includes v2 proc
 ```clojure
 obneyai/grain-core-v2
 {:git/url "https://github.com/ObneyAI/grain.git"
- :sha "6817ba3ab82b7fc916150ab4c783d5a1b36d2919"
+ :sha "1616dacab3e287fbabd6a5ca9fe3d0ee51326cf4"
  :deps/root "projects/grain-core-v2"}
 ```
 
@@ -18,7 +18,7 @@ Distributed coordination for multi-instance deployments. Coordinator election, t
 ```clojure
 obneyai/grain-control-plane
 {:git/url "https://github.com/ObneyAI/grain.git"
- :sha "6817ba3ab82b7fc916150ab4c783d5a1b36d2919"
+ :sha "1616dacab3e287fbabd6a5ca9fe3d0ee51326cf4"
  :deps/root "projects/grain-control-plane"}
 ```
 
@@ -31,7 +31,7 @@ Server-rendered reactive UIs with [Datastar](https://data-star.dev/). Streams hi
 ```clojure
 obneyai/grain-datastar
 {:git/url "https://github.com/ObneyAI/grain.git"
- :sha "6817ba3ab82b7fc916150ab4c783d5a1b36d2919"
+ :sha "1616dacab3e287fbabd6a5ca9fe3d0ee51326cf4"
  :deps/root "projects/grain-datastar"}
 ```
 
@@ -44,7 +44,7 @@ Dev-only nREPL-facing tools for coding agents working against a live Grain app. 
 ```clojure
 obneyai/grain-code-agent-tools
 {:git/url "https://github.com/ObneyAI/grain.git"
- :sha "6817ba3ab82b7fc916150ab4c783d5a1b36d2919"
+ :sha "1616dacab3e287fbabd6a5ca9fe3d0ee51326cf4"
  :deps/root "projects/grain-code-agent-tools"}
 ```
 
@@ -69,7 +69,7 @@ Multi-tenant Postgres backend with Row-Level Security, per-tenant advisory locks
 ```clojure
 obneyai/grain-event-store-postgres-v3
 {:git/url "https://github.com/ObneyAI/grain.git"
- :sha "6817ba3ab82b7fc916150ab4c783d5a1b36d2919"
+ :sha "1616dacab3e287fbabd6a5ca9fe3d0ee51326cf4"
  :deps/root "projects/grain-event-store-postgres-v3"}
 ```
 
@@ -80,7 +80,7 @@ Embedded SQLite backend implementing the v3 event store protocol for single-proc
 ```clojure
 obneyai/grain-event-store-sqlite-v3
 {:git/url "https://github.com/ObneyAI/grain.git"
- :sha "6817ba3ab82b7fc916150ab4c783d5a1b36d2919"
+ :sha "1616dacab3e287fbabd6a5ca9fe3d0ee51326cf4"
  :deps/root "projects/grain-event-store-sqlite-v3"}
 ```
 
@@ -91,7 +91,7 @@ obneyai/grain-event-store-sqlite-v3
 ```clojure
 obneyai/grain-mulog-aws-cloudwatch-emf-publisher
 {:git/url "https://github.com/ObneyAI/grain.git"
- :sha "6817ba3ab82b7fc916150ab4c783d5a1b36d2919"
+ :sha "1616dacab3e287fbabd6a5ca9fe3d0ee51326cf4"
  :deps/root "projects/grain-mulog-aws-cloudwatch-emf-publisher"}
 ```
 

--- a/projects/grain-event-store-sqlite-v3/test/ai/obney/grain/todo_processor_v2/commit_order_regression_test.clj
+++ b/projects/grain-event-store-sqlite-v3/test/ai/obney/grain/todo_processor_v2/commit_order_regression_test.clj
@@ -1,0 +1,66 @@
+(ns ai.obney.grain.todo-processor-v2.commit-order-regression-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [ai.obney.grain.event-store-v3.interface :as es]
+            [ai.obney.grain.event-store-sqlite-v3.interface]
+            [ai.obney.grain.schema-util.interface :refer [defschemas]]
+            [ai.obney.grain.todo-processor-v2.core :as tp]
+            [clj-uuid :as uuid])
+  (:import [java.io File]
+           [java.util UUID]))
+
+(defschemas commit-order-proof-schemas
+  {:commit-order/item [:map [:n :int]]})
+
+(defn- eventually?
+  [pred]
+  (loop [remaining 200]
+    (cond
+      (pred) true
+      (zero? remaining) false
+      :else (do (Thread/sleep 10) (recur (dec remaining))))))
+
+(deftest delayed-lower-id-event-is-not-lost-behind-checkpoint
+  (testing "append repairs caller ID order at the tenant serialization boundary"
+    (let [db-file (File/createTempFile "grain-commit-order-" ".sqlite")
+          _ (.delete db-file)
+          store (es/start {:conn {:type :sqlite
+                                  :database-file (.getAbsolutePath db-file)}})
+          tenant-id (random-uuid)
+          low-id (UUID/fromString "01900000-0000-7000-8000-000000000001")
+          high-id (UUID/fromString "01900000-0000-7000-8000-000000000002")
+          low (assoc (es/->event {:type :commit-order/item :body {:n 1}})
+                     :event/id low-id)
+          high (assoc (es/->event {:type :commit-order/item :body {:n 2}})
+                      :event/id high-id)
+          seen (atom [])
+          processor-name :commit-order/proof
+          old-registry @tp/processor-registry*]
+      (try
+        (es/append store {:tenant-id tenant-id :events [high]})
+        (reset! tp/processor-registry*
+                {processor-name
+                 {:topics #{:commit-order/item}
+                  :handler-fn (fn [{:keys [event]}]
+                                (swap! seen conj (:event/id event))
+                                {:result/events []})}})
+        (let [poller (tp/start-tenant-poller
+                      {:event-store store
+                       :tenant-ids #{tenant-id}
+                       :poll-interval-ms 10
+                       :batch-size 100})]
+          (try
+            (is (eventually? #(= [high-id] @seen)))
+            (let [[persisted-low] (es/append store
+                                    {:tenant-id tenant-id :events [low]})]
+              (is (uuid/< high-id (:event/id persisted-low)))
+              (is (eventually? #(= [high-id (:event/id persisted-low)] @seen)))
+              (is (= [high-id (:event/id persisted-low)]
+                     (mapv :event/id
+                           (es/read store {:tenant-id tenant-id
+                                           :types #{:commit-order/item}})))))
+            (finally
+              (tp/stop-tenant-poller poller))))
+        (finally
+          (reset! tp/processor-registry* old-registry)
+          (es/stop store)
+          (.delete db-file))))))

--- a/readme.md
+++ b/readme.md
@@ -43,7 +43,7 @@ Add to your `deps.edn`:
 ```clojure
 obneyai/grain-core-v2
 {:git/url "https://github.com/ObneyAI/grain.git"
- :git/sha "6817ba3ab82b7fc916150ab4c783d5a1b36d2919" ;; update to latest commit sha
+ :git/sha "1616dacab3e287fbabd6a5ca9fe3d0ee51326cf4" ;; update to latest commit sha
  :deps/root "projects/grain-core-v2"}
 ```
 

--- a/scripts/churn-test.clj
+++ b/scripts/churn-test.clj
@@ -67,6 +67,63 @@
   (reset! running false)
   (.join thread 5000))
 
+(defn percentile [values p]
+  (let [values (vec (sort values))
+        index (max 0 (dec (long (Math/ceil (* p (count values))))))]
+    (nth values (min index (dec (count values))))))
+
+(defn run-contention-load!
+  "Run writers inside the target JVM and return aggregate diagnostics only."
+  [tenant-ids writers appends-per-writer]
+  (eval-read port-a
+    (format
+      "(let [tenant-ids (mapv java.util.UUID/fromString %s)
+             writers %d
+             appends %d
+             ready (java.util.concurrent.CountDownLatch. writers)
+             start (java.util.concurrent.CountDownLatch. 1)
+             outcomes (atom [])
+             tasks (mapv
+                    (fn [writer]
+                      (future
+                        (.countDown ready)
+                        (.await start)
+                        (dotimes [n appends]
+                          (let [tenant-id (nth tenant-ids
+                                               (mod (+ writer n) (count tenant-ids)))
+                                before (System/nanoTime)]
+                            (try
+                              (let [returned (app/increment! @app/app tenant-id)]
+                                (swap! outcomes conj
+                                       {:ok (= 1 (count returned))
+                                        :latency-ns (- (System/nanoTime) before)}))
+                              (catch Throwable t
+                                (swap! outcomes conj
+                                       {:ok false :error (.getMessage t)
+                                        :latency-ns (- (System/nanoTime) before)})))))))
+                    (range writers))]
+         (.await ready 10 java.util.concurrent.TimeUnit/SECONDS)
+         (let [began (System/nanoTime)]
+           (.countDown start)
+           (doseq [task tasks] @task)
+           {:elapsed-ns (- (System/nanoTime) began)
+            :successes (count (filter :ok @outcomes))
+            :errors (count (remove :ok @outcomes))
+            :latencies-ns (mapv :latency-ns @outcomes)}))"
+      (pr-str (vec tenant-ids)) writers appends-per-writer)
+    120000))
+
+(defn report-load! [label result]
+  (let [latencies (:latencies-ns result)
+        elapsed-seconds (/ (:elapsed-ns result) 1.0e9)
+        ms #(/ % 1.0e6)]
+    (metric (format "%s: %.1f writes/s, p50=%.2fms p95=%.2fms p99=%.2fms"
+                    label
+                    (/ (:successes result) elapsed-seconds)
+                    (ms (percentile latencies 0.50))
+                    (ms (percentile latencies 0.95))
+                    (ms (percentile latencies 0.99))))))
+
 ;; -------------------------------- ;;
 ;; Node cycler                      ;;
 ;; -------------------------------- ;;
@@ -117,6 +174,17 @@
       (check (str n-tenants " leases assigned (got " (:leases sa) ")")
              (= n-tenants (:leases sa))))
     tids))
+
+(defn scenario-contention [tenant-ids]
+  (header "Churn: Sustained append contention")
+  (let [hot (run-contention-load! [(first tenant-ids)] 16 100)
+        distributed (run-contention-load! tenant-ids 16 100)]
+    (report-load! "Hot tenant (16x100)" hot)
+    (report-load! "Distributed across 20 tenants (1,600)" distributed)
+    (check "Hot tenant: all 1,600 appends succeeded"
+           (and (= 1600 (:successes hot)) (zero? (:errors hot))))
+    (check "Distributed: all 1,600 appends succeeded"
+           (and (= 1600 (:successes distributed)) (zero? (:errors distributed))))))
 
 (defn scenario-churn [tenant-ids]
   (header (str "Churn: " (/ test-duration-ms 1000) "s of events + node cycling"))
@@ -185,6 +253,7 @@
 
 (try
   (let [tids (scenario-setup)
+        _ (scenario-contention tids)
         tids (scenario-churn tids)]
     (scenario-verify tids))
   (catch Throwable t

--- a/scripts/live-test.clj
+++ b/scripts/live-test.clj
@@ -151,6 +151,7 @@
     "(mapv (fn [e]
              {:event-type (:event/type e)
               :event-id (some-> (:event/id e) str)
+              :event-timestamp (some-> (:event/timestamp e) str)
               :tenant-id (some-> (:grain/tenant-id e) str)
               :triggered-by (some-> (:triggered-by e) str)
               :processed-event-id (some-> (:processed-by/event-id e) str)
@@ -729,25 +730,32 @@
                                                       (:event/type %%)))
                                   (mapv (fn [e] {:type (:event/type e)
                                                  :id (str (:event/id e))
+                                                 :timestamp (str (:event/timestamp e))
                                                  :triggered-by (some-> (:triggered-by e) str)
                                                  :processed-event-id (some-> (:processed-by/event-id e) str)})))"
                            tenant-id))
           observed (wait-for-tail-probe-count primary-port 6 15000)
           increment-ids (set (map :id (filter #(= :test/counter-incremented (:type %)) stored)))
+          stored-increment-times (into {} (map (juxt :id :timestamp)
+                                                (filter #(= :test/counter-incremented (:type %)) stored)))
           processor-refs (set (keep :processed-event-id stored))
-          relevant-ids (set (vals (select-keys result
-                                               [:caller-a-id :caller-b-id
-                                                :final-a-id :final-b-id])))
+          relevant-ids #{final-a final-b}
           checkpoint-refs (->> stored
                                (keep :triggered-by)
                                (filter relevant-ids)
                                set)
           pubsub-increment-ids (set (keep :event-id
-                                          (filter #(= :test/counter-incremented (:event-type %)) observed)))]
+                                          (filter #(= :test/counter-incremented (:event-type %)) observed)))
+          pubsub-increment-times (into {} (map (juxt :event-id :event-timestamp)
+                                                (filter #(= :test/counter-incremented (:event-type %)) observed)))
+          returned-increment-times {final-a (:final-a-timestamp result)
+                                    final-b (:final-b-timestamp result)}]
       (info (str "Final IDs: B=" final-b ", A=" final-a))
       (check "A receives a final ID greater than B" (pos? (compare final-a final-b)))
       (check "Storage contains both final persisted IDs" (= #{final-a final-b} increment-ids))
       (check "Pubsub exposes the final persisted IDs" (= #{final-a final-b} pubsub-increment-ids))
+      (check "Storage and pubsub expose store-assigned timestamps"
+             (= returned-increment-times stored-increment-times pubsub-increment-times))
       (check "Processor output references only final IDs" (= #{final-a final-b} processor-refs))
       (check "Checkpoints reference only final IDs" (= #{final-a final-b} checkpoint-refs))
       (check "Tenant diagnostics report no gaps or anomalies"

--- a/scripts/live-test.clj
+++ b/scripts/live-test.clj
@@ -55,17 +55,21 @@
 ;; nREPL helpers                    ;;
 ;; -------------------------------- ;;
 
-(defn eval-on [port code]
-  (with-open [conn (nrepl/connect :port port)]
-    (let [client (nrepl/client conn 15000)
-          results (nrepl/message client {:op :eval :code code})]
-      (doseq [r results]
-        (when (:err r) (binding [*out* *err*] (print (:err r)))))
-      (some :value results))))
+(defn eval-on
+  ([port code] (eval-on port code 15000))
+  ([port code timeout-ms]
+   (with-open [conn (nrepl/connect :port port)]
+     (let [client (nrepl/client conn timeout-ms)
+           results (nrepl/message client {:op :eval :code code})]
+       (doseq [r results]
+         (when (:err r) (binding [*out* *err*] (print (:err r)))))
+       (some :value results)))))
 
-(defn eval-read [port code]
-  (let [v (eval-on port code)]
-    (when v (read-string v))))
+(defn eval-read
+  ([port code] (eval-read port code 15000))
+  ([port code timeout-ms]
+   (let [v (eval-on port code timeout-ms)]
+     (when v (read-string v)))))
 
 (defn setup-node! [port]
   ;; nREPL is opened inside (start) before (reset! app (start)) completes, so
@@ -126,11 +130,15 @@
     (format "(count (filter (fn [e] (= :test/counter-incremented (:event/type e)))
                             (app/all-events @app/app (java.util.UUID/fromString \"%s\"))))" tenant-id)))
 
-(defn start-tail-probe! [port tenant-id]
-  (eval-on port
-    (format "(app/start-tail-probe! @app/app
-                (java.util.UUID/fromString \"%s\")
-                #{:test/counter-incremented})" tenant-id)))
+(defn start-tail-probe!
+  ([port tenant-id]
+   (start-tail-probe! port tenant-id #{:test/counter-incremented}))
+  ([port tenant-id event-types]
+   (eval-on port
+     (format "(app/start-tail-probe! @app/app
+                 (java.util.UUID/fromString \"%s\")
+                 %s)"
+             tenant-id (pr-str event-types)))))
 
 (defn stop-tail-probe! [port]
   (eval-on port "(app/stop-tail-probe! @app/app)"))
@@ -142,7 +150,10 @@
   (eval-read port
     "(mapv (fn [e]
              {:event-type (:event/type e)
+              :event-id (some-> (:event/id e) str)
               :tenant-id (some-> (:grain/tenant-id e) str)
+              :triggered-by (some-> (:triggered-by e) str)
+              :processed-event-id (some-> (:processed-by/event-id e) str)
               :n (:n e)})
            (app/tail-probe-events @app/app))"))
 
@@ -552,18 +563,28 @@
                                          %s))"
                           (pr-str tids)))
           new-per-tenant (map (fn [tid] (- (get after tid 0) (get before tid 0))) tids)
-          total-new (reduce + new-per-tenant)]
+          total-new (reduce + new-per-tenant)
+          duplicate-periods (eval-read primary-port
+                              (format
+                                "(into {}
+                                   (map (fn [tid-str]
+                                          (let [events (app/all-events @app/app
+                                                         (java.util.UUID/fromString tid-str))
+                                                periods (map :period
+                                                          (filter #(= :test/scheduled-trigger
+                                                                      (:event/type %%))
+                                                                  events))]
+                                            [tid-str (- (count periods)
+                                                        (count (set periods)))]))
+                                        %s))"
+                                (pr-str tids)))]
       (info (str "New triggers per tenant: " (pr-str new-per-tenant)))
       (info (str "Total new: " total-new))
       (check "New triggers created" (pos? total-new))
-      ;; CAS dedup check: each tenant should get the same number of new triggers
-      ;; (one per cycle, not one per node per cycle)
-      ;; With 3 nodes and ~3 cycles, without dedup = ~9 per tenant.
-      ;; With dedup = ~3 per tenant.
-      (let [max-new (apply max new-per-tenant)]
-        (check (str "CAS dedup working (max " max-new " per tenant, not " (* 3 max-new) ")")
-               ;; Each tenant should have roughly the same count (within 1)
-               (<= (- (apply max new-per-tenant) (apply min new-per-tenant)) 1))))))
+      ;; Directly check the CAS invariant. Count comparisons are sensitive to
+      ;; events landing between the per-tenant baseline/final reads.
+      (check "CAS dedup working (no duplicate tenant/period triggers)"
+             (every? zero? (vals duplicate-periods))))))
 
 (defn scenario-15 []
   (header "Scenario 15: Blocking handlers don't starve other tenants")
@@ -668,6 +689,74 @@
         (check (str "Post-failover tenant " (subs tid 0 8) ": has local owner among survivors")
                (= 1 (count local-owners)))))))
 
+(defn scenario-17 []
+  (header "Scenario 17: Checkpoint gap uses final persisted IDs")
+  (restart-victim!)
+  (Thread/sleep 6000)
+  ;; A fresh tenant keeps every storage/reference assertion specific to the
+  ;; two events in this scenario. B's append also registers the tenant.
+  (let [tenant-id (str (java.util.UUID/randomUUID))]
+    (reset-tail-probe-events! primary-port)
+    (start-tail-probe! primary-port tenant-id
+                       #{:test/counter-incremented
+                         :test/counter-processed
+                         :grain/todo-processor-checkpoint})
+    (let [result (eval-read primary-port
+                   (format "(let [r (app/append-checkpoint-gap!
+                                      @app/app (java.util.UUID/fromString \"%s\") 15000)]
+                              (update-vals r str))" tenant-id)
+                   30000)
+          final-a (:final-a-id result)
+          final-b (:final-b-id result)
+          deadline (+ (System/currentTimeMillis) 15000)
+          diagnostic (loop []
+                       (let [d (eval-read primary-port
+                                 (format "(app/diagnose-tenant @app/app
+                                            (java.util.UUID/fromString \"%s\"))" tenant-id))]
+                         (if (or (and (>= (:processed d) 2)
+                                      (zero? (:missing-count d))
+                                      (zero? (:unexpected-count d))
+                                      (zero? (:uncheckpointed-count d)))
+                                 (>= (System/currentTimeMillis) deadline))
+                           d
+                           (do (Thread/sleep 100) (recur)))))
+          stored (eval-read primary-port
+                   (format "(->> (app/all-events @app/app
+                                   (java.util.UUID/fromString \"%s\"))
+                                  (filter #(contains? #{:test/counter-incremented
+                                                        :test/counter-processed
+                                                        :grain/todo-processor-checkpoint}
+                                                      (:event/type %%)))
+                                  (mapv (fn [e] {:type (:event/type e)
+                                                 :id (str (:event/id e))
+                                                 :triggered-by (some-> (:triggered-by e) str)
+                                                 :processed-event-id (some-> (:processed-by/event-id e) str)})))"
+                           tenant-id))
+          observed (wait-for-tail-probe-count primary-port 6 15000)
+          increment-ids (set (map :id (filter #(= :test/counter-incremented (:type %)) stored)))
+          processor-refs (set (keep :processed-event-id stored))
+          relevant-ids (set (vals (select-keys result
+                                               [:caller-a-id :caller-b-id
+                                                :final-a-id :final-b-id])))
+          checkpoint-refs (->> stored
+                               (keep :triggered-by)
+                               (filter relevant-ids)
+                               set)
+          pubsub-increment-ids (set (keep :event-id
+                                          (filter #(= :test/counter-incremented (:event-type %)) observed)))]
+      (info (str "Final IDs: B=" final-b ", A=" final-a))
+      (check "A receives a final ID greater than B" (pos? (compare final-a final-b)))
+      (check "Storage contains both final persisted IDs" (= #{final-a final-b} increment-ids))
+      (check "Pubsub exposes the final persisted IDs" (= #{final-a final-b} pubsub-increment-ids))
+      (check "Processor output references only final IDs" (= #{final-a final-b} processor-refs))
+      (check "Checkpoints reference only final IDs" (= #{final-a final-b} checkpoint-refs))
+      (check "Tenant diagnostics report no gaps or anomalies"
+             (and (zero? (:missing-count diagnostic))
+                  (zero? (:unexpected-count diagnostic))
+                  (empty? (:duplicate-processed diagnostic))
+                  (zero? (:uncheckpointed-count diagnostic))))
+      (stop-tail-probe! primary-port))))
+
 ;; -------------------------------- ;;
 ;; Main runner                      ;;
 
@@ -700,6 +789,7 @@
     (scenario-14)
     (scenario-15)
     (scenario-16)
+    (scenario-17)
 
     (catch Throwable t
       (swap! results update :error inc)


### PR DESCRIPTION
Circumstances can come about that cause event ids to be appended out of time order. Grain depends on event ids being appended in time order. Currently that can happen because event ids are generated when events are constructed via  the `->event` function or otherwise. Most of the time this is fine, but under high concurrent load while testing concurrent orc workflows, this issue surfaced. This work is intended to ensure a total ordering by moving the concern into the event store implementations, which control this at append time.