### PR TITLE
Serialize SQLite event-store writes and bound lock contention

### DIFF
--- a/components/event-store-sqlite-v3/event-store-sqlite-v3.allium
+++ b/components/event-store-sqlite-v3/event-store-sqlite-v3.allium
@@ -32,7 +32,8 @@
 --     (the tenant-id propagation guarantee is recorded as a contract obligation,
 --     but the bus itself is owned elsewhere)
 --   - the datasource extension point (pluggable :file / custom datasources),
---     logging, tracing and metrics, threads and pools
+--     logging transport, threads and pools; queueing, contention bounds and
+--     their observable measurements are behavioural and are included below
 --   - how UUID v7 ids are generated (an event arrives already identified); this
 --     backend relies only on their time-ordering, not on minting them
 --
@@ -151,6 +152,24 @@ contract EventLog {
         -- This is what makes a compare-and-swap append a sound concurrency
         -- fence — two writers racing on the same pre-state cannot both succeed.
 
+    @invariant BoundedContention
+        -- Appends admitted within the configured queue and contention bounds
+        -- absorb transient writer-lock contention. If the queue is already full
+        -- or the configured busy attempts are exhausted, the caller receives a
+        -- stable busy outcome rather than a raw database-lock exception. Every
+        -- retry repeats the entire atomic transaction; no partial attempt is
+        -- observable.
+
+    @invariant ReadsRemainConcurrent
+        -- Read operations are never placed behind the single-writer admission
+        -- boundary. Where the underlying store supports concurrent readers and
+        -- a writer, a queued or active append does not prevent those reads.
+
+    @invariant ContentionIsObservable
+        -- Queue depth and saturation, append and transaction latency, busy
+        -- retries, and exhausted contention are emitted as operational
+        -- measurements so load and overload can be distinguished.
+
     @invariant NewestRetrievedDirectly
         -- The newest matching event(s) for a tenant — a reverse read with a
         -- small limit, optionally narrowed by type and tag — are retrieved
@@ -264,6 +283,21 @@ entity Transaction {
     -- acting user, a reason). Arbitrary structured data, opaque to the store and
     -- carried inside the marker's body. Absent when the caller supplied none.
     metadata: Any?
+}
+
+------------------------------------------------------------
+-- Config
+------------------------------------------------------------
+
+config {
+    -- Millisecond values are represented as integers because contention policy
+    -- is configured directly at the storage-driver boundary.
+    busy_timeout_ms: Integer = 1000
+    busy_max_retries: Integer = 3
+    busy_retry_backoff_ms: Integer = 10
+    busy_retry_max_backoff_ms: Integer = 250
+    write_queue_capacity: Integer = 1024
+    write_shutdown_timeout_ms: Integer = 5000
 }
 
 ------------------------------------------------------------
@@ -489,6 +523,11 @@ surface EventAppend {
         -- A batch commits whole or not at all, and a checked append is a sound
         -- concurrency fence: serialized writers mean a compare-and-swap that
         -- passes truly observed the latest committed state for its tenant.
+
+    @guarantee BoundedAndObservableContention
+        -- Transient writer contention is handled within the configured bounds.
+        -- Saturation and exhausted contention return a stable busy result, and
+        -- queueing, latency, retry and saturation measurements are emitted.
 }
 
 -- The read boundary: how a client streams a tenant's events back, filtered and

--- a/components/event-store-sqlite-v3/src/ai/obney/grain/event_store_sqlite_v3/core.clj
+++ b/components/event-store-sqlite-v3/src/ai/obney/grain/event_store_sqlite_v3/core.clj
@@ -13,7 +13,10 @@
             [clj-uuid :as uuid])
   (:import [java.time OffsetDateTime]
            [java.util UUID]
-           [java.sql Connection]))
+           [java.sql Connection SQLException]
+           [java.util.concurrent ArrayBlockingQueue Callable CancellationException
+            ExecutionException FutureTask RejectedExecutionException ThreadFactory
+            ThreadPoolExecutor ThreadPoolExecutor$AbortPolicy TimeUnit]))
 
 ;; -------------------------- ;;
 ;; Event Store Initialization ;;
@@ -77,6 +80,8 @@
 ;; Integrant / Lifecycle Setup ;;
 ;; --------------------------- ;;
 
+(declare make-write-coordinator)
+
 (defn start
   [config]
   (u/trace
@@ -86,14 +91,21 @@
                  {::config config
                   ::connection-pool {::config (ig/ref ::config)}})]
      (init-idempotently system)
-     system)))
+     (assoc system ::write-coordinator (make-write-coordinator config)))))
 
 (defn stop
   [event-store]
   (u/trace
    ::stopping-event-store
    []
-   (ig/halt! event-store)))
+   (when-let [^ThreadPoolExecutor coordinator (::write-coordinator event-store)]
+     (.shutdown coordinator)
+     (when-not (.awaitTermination
+                coordinator
+                (long (or (get-in event-store [::config :write-shutdown-timeout-ms]) 5000))
+                TimeUnit/MILLISECONDS)
+       (run! #(.cancel ^FutureTask % true) (.shutdownNow coordinator))))
+   (ig/halt! (dissoc event-store ::write-coordinator))))
 
 (defmethod ig/init-key ::config [_ config]
   config)
@@ -107,6 +119,29 @@
 
 (defmethod ig/halt-key! ::connection-pool [_ connection-pool]
   (hikari/close-datasource connection-pool))
+
+(defn- make-write-coordinator
+  [config]
+  (let [capacity (long (or (:write-queue-capacity config) 1024))
+        thread-number (atom 0)]
+    (when-not (pos? capacity)
+      (throw (IllegalArgumentException. ":write-queue-capacity must be positive")))
+    (doseq [[key default] [[:busy-timeout-ms 1000]
+                           [:busy-max-retries 3]
+                           [:busy-retry-backoff-ms 10]
+                           [:busy-retry-max-backoff-ms 250]
+                           [:write-shutdown-timeout-ms 5000]]]
+      (when (neg? (long (get config key default)))
+        (throw (IllegalArgumentException. (str key " must not be negative")))))
+    (ThreadPoolExecutor.
+     1 1 0 TimeUnit/MILLISECONDS
+     (ArrayBlockingQueue. capacity true)
+     (reify ThreadFactory
+       (newThread [_ runnable]
+         (doto (Thread. runnable
+                        (str "grain-sqlite-writer-" (swap! thread-number inc)))
+           (.setDaemon true))))
+     (ThreadPoolExecutor$AbortPolicy.))))
 
 ;; -------------- ;;
 ;; Encoding       ;;
@@ -319,9 +354,10 @@
 
    We must keep auto-commit = true so that JDBC does not issue an implicit
    DEFERRED BEGIN before our explicit BEGIN IMMEDIATE statement runs."
-  [pool body-fn]
+  [pool busy-timeout-ms body-fn]
   (with-open [conn (jdbc/get-connection pool)]
     (.setAutoCommit ^Connection conn true)
+    (jdbc/execute! conn [(str "PRAGMA busy_timeout = " busy-timeout-ms)])
     (jdbc/execute! conn ["BEGIN IMMEDIATE"])
     (let [completed? (volatile! false)]
       (try
@@ -358,12 +394,33 @@
                     (jdbc/plan conn (into [sql] params)))]
         (if (= result ::none) (f) result)))))
 
-(defn append
+(defn- sqlite-contention?
+  [throwable]
+  (loop [cause throwable]
+    (cond
+      (nil? cause) false
+      (and (instance? SQLException cause)
+           (contains? #{5 6} (.getErrorCode ^SQLException cause))) true
+      :else (recur (.getCause ^Throwable cause)))))
+
+(defn- retry-backoff-ms
+  [config retry-number]
+  (let [initial (long (or (:busy-retry-backoff-ms config) 10))
+        maximum (long (or (:busy-retry-max-backoff-ms config) 250))]
+    (loop [remaining (dec retry-number)
+           delay (min initial maximum)]
+      (if (or (zero? remaining) (= delay maximum))
+        delay
+        (recur (dec remaining)
+               (if (> delay (quot maximum 2)) maximum (* 2 delay)))))))
+
+(defn- append-direct
   [event-store {{:keys [predicate-fn] :as cas} :cas
                 :keys [tenant-id events tx-metadata]}]
   (let [pool (get-in event-store [:state ::connection-pool])]
     (with-immediate-tx
       pool
+      (long (or (get-in event-store [:config :busy-timeout-ms]) 1000))
       (fn [conn]
         (let [last-id (committed-last-event-id conn tenant-id)
               persist! (fn []
@@ -383,6 +440,88 @@
                   (u/log ::cas-failed :anomaly anomaly)
                   anomaly)))
             (persist!)))))))
+
+(defn- append-with-busy-retry
+  [event-store args]
+  (let [config (:config event-store)
+        max-retries (long (or (:busy-max-retries config) 3))]
+    (loop [attempt 0]
+      (let [[status value]
+            (try
+              [:ok (u/trace ::write-transaction
+                     [:metric/name "SQLiteWriteTransaction"
+                      :metric/resolution :high
+                      :attempt (inc attempt)]
+                     (append-direct event-store args))]
+              (catch Throwable t [:error t]))]
+        (if (= :ok status)
+          value
+          (if (and (sqlite-contention? value) (< attempt max-retries))
+            (let [retry-number (inc attempt)
+                  backoff-ms (retry-backoff-ms config retry-number)]
+              (u/log :metric/metric
+                     :metric/name "SQLiteBusyRetry"
+                     :metric/value 1
+                     :metric/resolution :high
+                     :retry retry-number
+                     :backoff-ms backoff-ms)
+              (Thread/sleep backoff-ms)
+              (recur retry-number))
+            (if (sqlite-contention? value)
+              (do
+                (u/log :metric/metric
+                       :metric/name "SQLiteBusyExhausted"
+                       :metric/value 1
+                       :metric/resolution :high
+                       :attempts (inc attempt))
+                {::anom/category ::anom/busy
+                 ::anom/message "SQLite event-store contention limit exhausted"
+                 ::busy-attempts (inc attempt)})
+              (throw value))))))))
+
+(defn append
+  [event-store args]
+  (let [^ThreadPoolExecutor coordinator
+        (get-in event-store [:state ::write-coordinator])
+        queued-at (System/nanoTime)
+        task (FutureTask.
+              ^Callable
+              (reify Callable
+                (call [_]
+                  (let [queue-wait-ns (- (System/nanoTime) queued-at)]
+                    (u/log :metric/metric
+                           :metric/name "SQLiteWriteQueueWait"
+                           :metric/value queue-wait-ns
+                           :metric/resolution :high)
+                    (u/log :metric/metric
+                           :metric/name "SQLiteWriteQueueDepth"
+                           :metric/value (.size (.getQueue coordinator))
+                           :metric/resolution :high)
+                    (u/trace ::append
+                      [:metric/name "SQLiteAppend"
+                       :metric/resolution :high
+                       :queue-wait-ns queue-wait-ns]
+                      (append-with-busy-retry event-store args))))))]
+    (try
+      (.execute coordinator task)
+      (u/log :metric/metric
+             :metric/name "SQLiteWriteQueueDepth"
+             :metric/value (.size (.getQueue coordinator))
+             :metric/resolution :high)
+      (try
+        (.get task)
+        (catch ExecutionException e
+          (throw (.getCause e)))
+        (catch CancellationException e
+          (throw (IllegalStateException. "SQLite event-store writer stopped" e))))
+      (catch RejectedExecutionException _
+        (u/log :metric/metric
+               :metric/name "SQLiteWriteQueueSaturated"
+               :metric/value 1
+               :metric/resolution :high
+               :queue-capacity (or (get-in event-store [:config :write-queue-capacity]) 1024))
+        {::anom/category ::anom/busy
+         ::anom/message "SQLite event-store write queue is full"}))))
 
 ;; ----------- ;;
 ;; Tenants     ;;

--- a/components/event-store-sqlite-v3/src/ai/obney/grain/event_store_sqlite_v3/interface/datasource.clj
+++ b/components/event-store-sqlite-v3/src/ai/obney/grain/event_store_sqlite_v3/interface/datasource.clj
@@ -23,7 +23,10 @@
             "SQLite datasource requires :database-file (path or \":memory:\")")))
   (hikari/make-datasource
    (-> config
-       (dissoc :database-file :type)
+       (dissoc :database-file :type
+               :busy-timeout-ms :busy-max-retries
+               :busy-retry-backoff-ms :busy-retry-max-backoff-ms
+               :write-queue-capacity :write-shutdown-timeout-ms)
        (assoc :jdbc-url (str "jdbc:sqlite:" database-file)
               :driver-class-name "org.sqlite.JDBC"
               :maximum-pool-size (or (:maximum-pool-size config) 4)

--- a/components/event-store-sqlite-v3/test/ai/obney/grain/event_store_sqlite_v3/datasource_test.clj
+++ b/components/event-store-sqlite-v3/test/ai/obney/grain/event_store_sqlite_v3/datasource_test.clj
@@ -11,6 +11,18 @@
         (is (= "org.sqlite.JDBC" (:driver-class-name @captured)))
         (is (= "PRAGMA foreign_keys = ON" (:connection-init-sql @captured)))))))
 
+(deftest file-config-propagates-explicit-busy-timeout
+  (let [captured (atom nil)]
+    (with-redefs [hikari-cp.core/make-datasource (fn [config] (reset! captured config) :mock-ds)]
+      (datasource/make-datasource {:database-file "/tmp/foo.sqlite"
+                                   :busy-timeout-ms 73
+                                   :busy-max-retries 2
+                                   :write-queue-capacity 8})
+      (is (= "PRAGMA foreign_keys = ON" (:connection-init-sql @captured)))
+      (is (not (contains? @captured :busy-timeout-ms)))
+      (is (not (contains? @captured :busy-max-retries)))
+      (is (not (contains? @captured :write-queue-capacity))))))
+
 (deftest memory-config-builds-jdbc-url
   (let [captured (atom nil)]
     (with-redefs [hikari-cp.core/make-datasource (fn [config] (reset! captured config) :mock-ds)]

--- a/components/event-store-sqlite-v3/test/ai/obney/grain/event_store_sqlite_v3/integration_test.clj
+++ b/components/event-store-sqlite-v3/test/ai/obney/grain/event_store_sqlite_v3/integration_test.clj
@@ -89,6 +89,18 @@
 (defn tx-events [events]
   (filterv #(= :grain/tx (:event/type %)) events))
 
+(defn- with-configured-store [config f]
+  (let [tmp (File/createTempFile "grain-sqlite-policy-" ".sqlite")
+        _ (.delete tmp)
+        path (.getAbsolutePath tmp)
+        store (es/start {:conn (merge {:type :sqlite :database-file path} config)})]
+    (try
+      (f store)
+      (finally
+        (es/stop store)
+        (.delete (File. path))
+        (delete-sidecar-files path)))))
+
 ;; ======================== ;;
 ;; A. Lifecycle             ;;
 ;; ======================== ;;
@@ -892,6 +904,85 @@
     (is (= 1 (count conflicts)))
     (is (= 1 (count (non-tx-events (into [] (es/read store {:tenant-id tenant-id
                                                             :types #{:test/alpha}}))))))))
+
+(deftest transient-external-writer-contention-is-retried
+  (with-configured-store
+    {:busy-timeout-ms 20 :busy-max-retries 10
+     :busy-retry-backoff-ms 5 :busy-retry-max-backoff-ms 20}
+    (fn [store]
+      (let [pool (get-in store [:state ::sqlite-core/connection-pool])
+            tenant-id (uuid/v4)
+            event (es/->event {:type :test/alpha :body {:n 1}})]
+        (with-open [lock-conn (jdbc/get-connection pool)]
+          (jdbc/execute! lock-conn ["BEGIN IMMEDIATE"])
+          (let [result (future (es/append store {:tenant-id tenant-id :events [event]}))]
+            (Thread/sleep 100)
+            (jdbc/execute! lock-conn ["ROLLBACK"])
+            (is (= 1 (count (deref result 5000 ::timeout))))))
+        (is (= 1 (count (non-tx-events
+                         (into [] (es/read store {:tenant-id tenant-id}))))))))))
+
+(deftest exhausted-external-writer-contention-is-bounded
+  (with-configured-store
+    {:busy-timeout-ms 10 :busy-max-retries 1
+     :busy-retry-backoff-ms 1 :busy-retry-max-backoff-ms 1}
+    (fn [store]
+      (let [pool (get-in store [:state ::sqlite-core/connection-pool])
+            tenant-id (uuid/v4)
+            event (es/->event {:type :test/alpha :body {:n 1}})]
+        (with-open [lock-conn (jdbc/get-connection pool)]
+          (jdbc/execute! lock-conn ["BEGIN IMMEDIATE"])
+          (let [started (System/nanoTime)
+                result (es/append store {:tenant-id tenant-id :events [event]})
+                elapsed-ms (/ (- (System/nanoTime) started) 1e6)]
+            (is (= ::anom/busy (::anom/category result)))
+            (is (= 2 (::sqlite-core/busy-attempts result)))
+            (is (< elapsed-ms 1000))
+            (jdbc/execute! lock-conn ["ROLLBACK"])))
+        (is (empty? (into [] (es/read store {:tenant-id tenant-id}))))))))
+
+(deftest wal-read-continues-while-writer-lock-is-held
+  (with-configured-store
+    {:busy-timeout-ms 20}
+    (fn [store]
+      (let [pool (get-in store [:state ::sqlite-core/connection-pool])
+            tenant-id (uuid/v4)
+            event (es/->event {:type :test/alpha :body {:n 1}})]
+        (es/append store {:tenant-id tenant-id :events [event]})
+        (with-open [lock-conn (jdbc/get-connection pool)]
+          (jdbc/execute! lock-conn ["BEGIN IMMEDIATE"])
+          (try
+            (let [read-result (future (into [] (es/read store {:tenant-id tenant-id})))]
+              (is (= 1 (count (non-tx-events
+                               (deref read-result 1000 ::timeout))))))
+            (finally
+              (jdbc/execute! lock-conn ["ROLLBACK"]))))))))
+
+(deftest saturated-write-queue-rejects-deterministically
+  (with-configured-store
+    {:write-queue-capacity 1}
+    (fn [store]
+      (let [tenant-id (uuid/v4)
+            entered (promise)
+            release (promise)
+            blocking-cas {:predicate-fn (fn [_] (deliver entered true) @release true)}
+            event #(es/->event {:type :test/alpha :body {:n %}})
+            active (future (es/append store {:tenant-id tenant-id :events [(event 1)]
+                                             :cas blocking-cas}))]
+        (is (= true (deref entered 5000 ::timeout)))
+        (let [queued (future (es/append store {:tenant-id tenant-id :events [(event 2)]}))
+              coordinator (get-in store [:state ::sqlite-core/write-coordinator])]
+          (loop [remaining 100]
+            (when (and (zero? (.size (.getQueue coordinator))) (pos? remaining))
+              (Thread/sleep 5)
+              (recur (dec remaining))))
+          (let [rejected (es/append store {:tenant-id tenant-id :events [(event 3)]})]
+            (is (= ::anom/busy (::anom/category rejected))))
+          (deliver release true)
+          (is (= 1 (count (deref active 5000 ::timeout))))
+          (is (= 1 (count (deref queued 5000 ::timeout))))
+          (is (= 2 (count (non-tx-events
+                           (into [] (es/read store {:tenant-id tenant-id})))))))))))
 
 ;; ===================================================== ;;
 ;; Reverse / Limit single-read primitive + EXPLAIN       ;;

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -94,7 +94,7 @@ obneyai/grain-event-store-postgres-v3
 
 ## grain-event-store-sqlite-v3
 
-Embedded SQLite backend implementing the v3 event store protocol for single-process deployments where running Postgres is overkill. WAL mode with `BEGIN IMMEDIATE` per append, a tenant-scoped events table plus a normalized `event_tags` join table for indexed superset tag filtering, and Fressian binary serialization. Same tenant-scoped API as the Postgres backend — swap the `:conn` type to move between them:
+Embedded SQLite backend implementing the v3 event store protocol for single-process deployments where running Postgres is overkill. WAL mode with a bounded single-writer queue and `BEGIN IMMEDIATE` per append, a tenant-scoped events table plus a normalized `event_tags` join table for indexed superset tag filtering, and Fressian binary serialization. Reads continue to use the connection pool concurrently; increasing the pool size improves available read concurrency but cannot increase SQLite's single-writer throughput. Same tenant-scoped API as the Postgres backend — swap the `:conn` type to move between them:
 
 ```clojure
 obneyai/grain-event-store-sqlite-v3
@@ -102,6 +102,22 @@ obneyai/grain-event-store-sqlite-v3
  :git/sha "382e7adc66ba347fd88e20b66cf02e737370c395"
  :deps/root "projects/grain-event-store-sqlite-v3"}
 ```
+
+SQLite contention policy is configured inside `:conn`:
+
+```clojure
+{:type :sqlite
+ :database-file "grain.sqlite"
+ :maximum-pool-size 4
+ :write-queue-capacity 1024
+ :busy-timeout-ms 1000
+ :busy-max-retries 3
+ :busy-retry-backoff-ms 10
+ :busy-retry-max-backoff-ms 250
+ :write-shutdown-timeout-ms 5000}
+```
+
+The queue admits one active write plus `:write-queue-capacity` waiting writes. A full queue returns a `cognitect.anomalies/busy` result immediately. SQLite busy/locked results retry the complete transaction with capped exponential backoff; exhaustion also returns a busy anomaly rather than exposing a raw `SQLITE_BUSY` exception. Keep at least two pooled connections when reads must proceed alongside a writer; the default is four. A larger pool can serve more simultaneous reads, but still cannot create a second SQLite writer. Grain emits μ/log metrics named `SQLiteWriteQueueDepth`, `SQLiteWriteQueueWait`, `SQLiteAppend`, `SQLiteWriteTransaction`, `SQLiteBusyRetry`, `SQLiteBusyExhausted`, and `SQLiteWriteQueueSaturated`.
 
 ## grain-mulog-aws-cloudwatch-emf-publisher
 


### PR DESCRIPTION
  Route SQLite event-store appends through a bounded, single-threaded FIFO
  write coordinator. SQLite permits only one writer even in WAL mode, so
  allowing pooled connections to begin write transactions concurrently
  caused normal lock contention to escape to callers as SQLITE_BUSY.

  Keep reads outside the write coordinator so they can continue concurrently
  where WAL mode permits. The connection pool remains useful for read
  concurrency, but is no longer treated as a way to increase write throughput.

  Add an explicit contention policy with configurable defaults:

  - :write-queue-capacity         1024
  - :busy-timeout-ms              1000
  - :busy-max-retries             3
  - :busy-retry-backoff-ms        10
  - :busy-retry-max-backoff-ms    250
  - :write-shutdown-timeout-ms    5000

  Apply busy_timeout before each write transaction and retry recognized
  SQLITE_BUSY and SQLITE_LOCKED failures using capped exponential backoff.
  Each retry reruns the complete BEGIN IMMEDIATE transaction, preserving
  atomicity and ensuring no partial attempt is observable.

  Return a cognitect.anomalies/busy result when the write queue is full or
  the configured contention attempts are exhausted. This prevents raw
  database-lock exceptions from leaking through the event-store boundary
  while keeping overload behavior bounded and predictable.

  Preserve the existing transaction semantics:

  - prepare store-owned event IDs and timestamps after writer serialization
  - evaluate CAS predicates inside the serialized transaction
  - commit event batches, tags, transaction markers, and tenant watermarks atomically
  - roll back the complete transaction on conflicts or failures
  - retain UUID-v7 event ordering and CAS fencing guarantees

  Integrate the writer coordinator with event-store lifecycle management.
  Shutdown rejects new work, allows admitted writes to drain for the
  configured period, and cancels queued work if the deadline expires before
  closing the connection pool.

  Emit μ/log measurements for:

  - SQLiteWriteQueueDepth
  - SQLiteWriteQueueWait
  - SQLiteAppend
  - SQLiteWriteTransaction
  - SQLiteBusyRetry
  - SQLiteBusyExhausted
  - SQLiteWriteQueueSaturated

  Add deterministic integration coverage that:

  - holds an external SQLite writer lock and verifies a transiently blocked append succeeds within the configured retry bound
  - verifies prolonged contention returns a bounded busy anomaly
  - fills the write queue and verifies deterministic saturation behavior
  - verifies WAL reads continue while a writer lock is held
  - retains existing concurrent hot-tenant, multi-tenant, ordering, transaction, and CAS serialization coverage

  Document the new SQLite contention and connection-pool policies, including
  that at least two pooled connections are recommended for concurrent reads
  and writes and that increasing pool size does not create additional SQLite
  write capacity.

  Update the SQLite event-store Allium contract with bounded contention,
  concurrent-read, observability, and configuration guarantees.